### PR TITLE
chore: add .golangci.yaml, ARCHITECTURE.md, fix gocritic lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,22 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - govet
+    - staticcheck
+    - ineffassign
+    - unused
+    - errcheck
+    - gocritic
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - fmt.Print
+        - fmt.Printf
+        - fmt.Println

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,74 @@
+# Architecture
+
+`jk` is a CLI for Jenkins controllers modeled after the GitHub CLI (`gh`).
+It is written in Go 1.25+ using [Cobra](https://github.com/spf13/cobra) for
+command routing and [go-resty](https://github.com/go-resty/resty) for HTTP.
+
+## Directory layout
+
+```
+cmd/jk/                  Entry point — calls internal/jkcmd.Main()
+internal/
+  jkcmd/                 CLI bootstrap, factory wiring
+  jenkins/               HTTP client, CSRF crumb handling, path helpers
+  config/                YAML configuration (~/.config/jk/config.yaml)
+  secret/                OS keyring token storage (fallback: encrypted file)
+  build/                 Version info injected via ldflags
+  log/                   Structured logging (zerolog)
+  filter/                JQ-style JSON filtering
+  fuzzy/                 Fuzzy-match helpers for interactive selection
+  terminal/              TTY detection utilities
+  i18n/                  Internationalisation stubs
+pkg/
+  cmd/<command>/         One package per top-level command:
+                           artifact, auth, context, cred, job, log,
+                           node, plugin, queue, run, search, test, version
+  cmd/root/              Root command and help renderer
+  cmd/shared/            Shared helpers — output formatting, log streaming,
+                           jq integration, template rendering, time formatting
+  cmd/factory/           Factory constructor (builds the dependency graph)
+  cmdutil/               Factory interface, ExitError, exit codes
+  iostreams/             I/O abstraction — TTY, colour, pager, progress bars
+docs/                    User-facing specification (docs/spec.md)
+test/e2e/                End-to-end tests using testcontainers-go (Jenkins in Docker)
+hack/                    Developer scripts
+examples/                Example usage files
+```
+
+## Execution flow
+
+```
+main.go
+  → jkcmd.Main()
+    → jkfactory.New(version)          build Factory
+    → root.NewCmdRoot(factory)         register all sub-commands
+    → rootCmd.Execute()                Cobra dispatch
+      → pkg/cmd/<command>/*.go         command handler
+        → shared.JenkinsClient(…)      resolve context + build client
+          → jenkins.Client.Do(req)     HTTP call with CSRF crumb
+```
+
+## Key abstractions
+
+**Factory** (`pkg/cmdutil/Factory`) — dependency-injection root providing
+IOStreams, Config loader, and a lazy JenkinsClient builder.
+
+**Jenkins client** (`internal/jenkins/Client`) — created per-context; handles
+CSRF crumbs, TLS/proxy settings, and capability detection via `/api/json`.
+
+**Multi-context** — contexts stored in `~/.config/jk/config.yaml`; tokens in
+the OS keyring.  Resolution order: `--context` flag → `JK_CONTEXT` env →
+active context in config.
+
+**IOStreams** (`pkg/iostreams`) — wraps stdin/stdout/stderr with TTY detection,
+colour support, pager piping, and progress indicators.
+
+## Testing strategy
+
+| Layer | Count | Runner |
+|-------|-------|--------|
+| Unit tests | ~230 (23 test files) | `go test ./...` with `JK_E2E_DISABLE=1` |
+| End-to-end | ~60 (test/e2e/) | testcontainers-go — spins up a real Jenkins in Docker |
+
+CI runs lint → unit → e2e in sequence.  The e2e suite uses git worktrees
+(`.tmp-jk-e2e/`) to isolate each test's Jenkins home directory.

--- a/internal/fuzzy/fuzzy.go
+++ b/internal/fuzzy/fuzzy.go
@@ -99,13 +99,14 @@ func calculateScore(query, target string) int {
 	wordMatched := false
 	for _, qWord := range queryWords {
 		for _, tWord := range targetWords {
-			if qWord == tWord {
+			switch {
+			case qWord == tWord:
 				score += 80
 				wordMatched = true
-			} else if strings.HasPrefix(tWord, qWord) {
+			case strings.HasPrefix(tWord, qWord):
 				score += 40
 				wordMatched = true
-			} else if strings.Contains(tWord, qWord) {
+			case strings.Contains(tWord, qWord):
 				score += 20
 				wordMatched = true
 			}

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -17,9 +17,7 @@ func New(appVersion string) (*cmdutil.Factory, error) {
 		IOStreams:      ios,
 	}
 
-	f.Config = func() (*config.Config, error) {
-		return config.Load()
-	}
+	f.Config = config.Load
 
 	return f, nil
 }

--- a/pkg/cmd/run/queue_test.go
+++ b/pkg/cmd/run/queue_test.go
@@ -170,7 +170,9 @@ func TestIncludeQueuedWithLimit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Simulate the logic from executeRunList
-			items := append(tt.queuedItems, tt.buildItems...)
+			var items []runListItem
+			items = append(items, tt.queuedItems...)
+			items = append(items, tt.buildItems...)
 
 			// Apply limit (same logic as in executeRunList)
 			if len(items) > tt.limit {
@@ -259,7 +261,9 @@ func TestCursorRecomputationWithQueuedItems(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Simulate the cursor recomputation logic from executeRunList
 			originalBuilds := tt.buildItems
-			items := append(tt.queuedItems, tt.buildItems...)
+			var items []runListItem
+			items = append(items, tt.queuedItems...)
+			items = append(items, tt.buildItems...)
 
 			var cursorBuild int64 = 0
 

--- a/pkg/cmd/run/start_params_test.go
+++ b/pkg/cmd/run/start_params_test.go
@@ -71,7 +71,9 @@ func TestParamFlagWithComma(t *testing.T) {
 			cmd := newRunStartCmd(nil)
 
 			// Add a dummy job arg (required by the command)
-			fullArgs := append(tc.args, "dummy/job")
+			fullArgs := make([]string, 0, len(tc.args)+1)
+			fullArgs = append(fullArgs, tc.args...)
+			fullArgs = append(fullArgs, "dummy/job")
 			cmd.SetArgs(fullArgs)
 
 			// Parse flags only (don't execute RunE which needs a real client)

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -338,7 +338,7 @@ func (s *IOStreams) startTextualProgressIndicator(label string) {
 	// Add an ellipsis to the label if it doesn't already have one.
 	ellipsis := "..."
 	if !strings.HasSuffix(label, ellipsis) {
-		label = label + ellipsis
+		label += ellipsis
 	}
 
 	_, _ = fmt.Fprintf(s.ErrOut, "%s%s", s.ColorScheme().Cyan(label), "\n")


### PR DESCRIPTION
## Summary
- Add explicit `.golangci.yaml` (v2 format) enabling govet, staticcheck, ineffassign, unused, errcheck, and gocritic with 5m timeout
- Add `ARCHITECTURE.md` documenting directory layout, execution flow, key abstractions, and testing strategy
- Fix 6 gocritic findings: `ifElseChain` → switch, `unlambda` → direct function ref, `appendAssign` (x3) → safe slice construction, `assignOp` → `+=`

## Test plan
- [x] `golangci-lint run ./...` passes with zero issues
- [x] `JK_E2E_DISABLE=1 go test ./...` passes (all unit tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)