### PR TITLE
feat: wire --quiet flag to suppress resty HTTP client warnings

### DIFF
--- a/.claude/skills/jk/SKILL.md
+++ b/.claude/skills/jk/SKILL.md
@@ -365,6 +365,7 @@ jk run start team/app --quiet
 ## Environment Variables
 
 - `JK_CONTEXT` — Override active context
+- `JK_QUIET` — Equivalent to `--quiet` (any value enables)
 
 ## Exit Codes
 

--- a/.claude/skills/jk/references/commands.md
+++ b/.claude/skills/jk/references/commands.md
@@ -427,6 +427,7 @@ All commands support:
 ## Environment Variables
 
 - `JK_CONTEXT` — Override active context (empty = use config)
+- `JK_QUIET` — Equivalent to `--quiet` (any value enables)
 
 ## Exit Codes
 

--- a/.codex/skills/jk/SKILL.md
+++ b/.codex/skills/jk/SKILL.md
@@ -365,6 +365,7 @@ jk run start team/app --quiet
 ## Environment Variables
 
 - `JK_CONTEXT` — Override active context
+- `JK_QUIET` — Equivalent to `--quiet` (any value enables)
 
 ## Exit Codes
 

--- a/.codex/skills/jk/references/commands.md
+++ b/.codex/skills/jk/references/commands.md
@@ -427,6 +427,7 @@ All commands support:
 ## Environment Variables
 
 - `JK_CONTEXT` — Override active context (empty = use config)
+- `JK_QUIET` — Equivalent to `--quiet` (any value enables)
 
 ## Exit Codes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `--quiet`/`-q` now also suppresses resty HTTP client warnings (e.g. "Using Basic Auth in HTTP mode") for plain-HTTP Jenkins instances.
+
 ## [0.0.15] - 2026-01-27
 
 ### Fixed

--- a/docs/agent-cookbook.md
+++ b/docs/agent-cookbook.md
@@ -2,6 +2,14 @@
 
 This guide captures common automation recipes for agents that integrate with the `jk` CLI. Each pattern includes the CLI call and a lightweight code example (Python unless noted) to embed in bots or orchestrators.
 
+> **Tip:** If your Jenkins instance uses HTTP (not HTTPS), suppress resty
+> client warnings with the existing `--quiet`/`-q` flag or `JK_QUIET=1`:
+>
+> ```bash
+> jk -q run ls team/app/pipeline          # per-invocation
+> export JK_QUIET=1                        # permanent (add to shell profile)
+> ```
+
 ## 1. Latest deployment for a specific chart
 
 **Problem:** Fetch the most recent run that deployed a given Helm chart.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -293,6 +293,7 @@ Key workflows the CLI must make trivial:
 - On context activation, probe `/jk/api/status`, `/sse-gateway/`, and `/prometheus` once; cache capability flags for 60 seconds or until an operation fails with 404/403/5xx.
 - Capability flags include `hasRunsFacade`, `hasCredentialFacade`, `hasEventRouter`, `hasPrometheus`, and `hasSSE`.
 - Commands fall back to core APIs when a capability is absent and emit a single informational warning (suppressed with `--quiet`).
+- `--quiet` (or `JK_QUIET`) also suppresses HTTP client library warnings such as the resty "Using Basic Auth in HTTP mode" message emitted for plain-HTTP Jenkins instances.
 
 ### 9.11 Artifact download semantics
 - `jk artifact download` accepts `--pattern` globs (default `**/*`) using case-sensitive matching consistent with Go filepath globbing.

--- a/internal/jenkins/client.go
+++ b/internal/jenkins/client.go
@@ -72,8 +72,24 @@ type statusResponse struct {
 	RecommendedClient string   `json:"recommendedClient"`
 }
 
+// ClientOption configures a Client during construction.
+type ClientOption func(*Client)
+
+// WithDisableWarn returns an option that suppresses HTTP client warnings
+// (e.g. resty's "Using Basic Auth in HTTP mode is not secure").
+func WithDisableWarn(disable bool) ClientOption {
+	return func(c *Client) {
+		if disable {
+			c.resty.SetDisableWarn(true)
+			if c.restyStream != nil {
+				c.restyStream.SetDisableWarn(true)
+			}
+		}
+	}
+}
+
 // NewClient constructs a Jenkins client for the supplied context.
-func NewClient(ctx context.Context, cfg *config.Config, contextName string) (*Client, error) {
+func NewClient(ctx context.Context, cfg *config.Config, contextName string, opts ...ClientOption) (*Client, error) {
 	if cfg == nil {
 		return nil, errors.New("configuration is required")
 	}
@@ -167,6 +183,11 @@ func NewClient(ctx context.Context, cfg *config.Config, contextName string) (*Cl
 		ctxConfig:   ctxDef,
 	}
 
+	// Apply options before any network calls.
+	for _, opt := range opts {
+		opt(client)
+	}
+
 	if err := client.refreshCapabilities(ctx); err != nil {
 		log.L().Warn().Err(err).Msg("capability detection failed")
 	}
@@ -215,6 +236,15 @@ func (c *Client) Context() *config.Context {
 // ContextName exposes the context identifier backing the client.
 func (c *Client) ContextName() string {
 	return c.contextName
+}
+
+// SetDisableWarn suppresses HTTP client warnings on both the standard
+// and streaming resty clients (e.g. "Using Basic Auth in HTTP mode").
+func (c *Client) SetDisableWarn(disable bool) {
+	c.resty.SetDisableWarn(disable)
+	if c.restyStream != nil {
+		c.restyStream.SetDisableWarn(disable)
+	}
 }
 
 // Do executes the request with crumb handling.

--- a/internal/jenkins/client_test.go
+++ b/internal/jenkins/client_test.go
@@ -1,0 +1,111 @@
+package jenkins
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+)
+
+// restyDisableWarn reads the DisableWarn field from a resty.Client using reflection,
+// since resty does not expose a getter for this field.
+func restyDisableWarn(t *testing.T, rc *resty.Client) bool {
+	t.Helper()
+	v := reflect.ValueOf(rc).Elem().FieldByName("DisableWarn")
+	if !v.IsValid() {
+		t.Fatal("resty.Client has no DisableWarn field; resty API may have changed")
+	}
+	return v.Bool()
+}
+
+func TestWithDisableWarnTrue(t *testing.T) {
+	rc := resty.New()
+	rs := resty.New()
+	c := &Client{resty: rc, restyStream: rs}
+
+	opt := WithDisableWarn(true)
+	opt(c)
+
+	if !restyDisableWarn(t, rc) {
+		t.Error("expected resty client DisableWarn=true after WithDisableWarn(true), got false")
+	}
+	if !restyDisableWarn(t, rs) {
+		t.Error("expected restyStream DisableWarn=true after WithDisableWarn(true), got false")
+	}
+}
+
+func TestWithDisableWarnFalse(t *testing.T) {
+	rc := resty.New()
+	rc.SetDisableWarn(true)
+	rs := resty.New()
+	rs.SetDisableWarn(true)
+	c := &Client{resty: rc, restyStream: rs}
+
+	// WithDisableWarn(false) should be a no-op — it must NOT clear an existing true value.
+	opt := WithDisableWarn(false)
+	opt(c)
+
+	// The original true value should be unchanged because the option only acts when disable==true.
+	if !restyDisableWarn(t, rc) {
+		t.Error("WithDisableWarn(false) should not clear an existing DisableWarn=true on resty client")
+	}
+}
+
+func TestWithDisableWarnNilStream(t *testing.T) {
+	rc := resty.New()
+	c := &Client{resty: rc, restyStream: nil}
+
+	// Must not panic when restyStream is nil.
+	opt := WithDisableWarn(true)
+	opt(c)
+
+	if !restyDisableWarn(t, rc) {
+		t.Error("expected resty client DisableWarn=true, got false")
+	}
+}
+
+func TestClientOptionDefaultNoDisableWarn(t *testing.T) {
+	rc := resty.New()
+	rs := resty.New()
+	c := &Client{resty: rc, restyStream: rs}
+
+	// Applying no options must leave DisableWarn at its default (false).
+	var opts []ClientOption
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	if restyDisableWarn(t, rc) {
+		t.Error("expected resty client DisableWarn=false by default, got true")
+	}
+	if restyDisableWarn(t, rs) {
+		t.Error("expected restyStream DisableWarn=false by default, got true")
+	}
+}
+
+func TestSetDisableWarn(t *testing.T) {
+	rc := resty.New()
+	rs := resty.New()
+	c := &Client{resty: rc, restyStream: rs}
+
+	c.SetDisableWarn(true)
+
+	if !restyDisableWarn(t, rc) {
+		t.Error("SetDisableWarn(true): expected resty DisableWarn=true, got false")
+	}
+	if !restyDisableWarn(t, rs) {
+		t.Error("SetDisableWarn(true): expected restyStream DisableWarn=true, got false")
+	}
+}
+
+func TestSetDisableWarnNilStream(t *testing.T) {
+	rc := resty.New()
+	c := &Client{resty: rc, restyStream: nil}
+
+	// Must not panic when restyStream is nil.
+	c.SetDisableWarn(true)
+
+	if !restyDisableWarn(t, rc) {
+		t.Error("SetDisableWarn(true): expected resty DisableWarn=true, got false")
+	}
+}

--- a/pkg/cmd/shared/shared.go
+++ b/pkg/cmd/shared/shared.go
@@ -174,5 +174,10 @@ func JenkinsClient(cmd *cobra.Command, f *cmdutil.Factory) (*jenkins.Client, err
 		ctx = context.Background()
 	}
 
-	return f.Client(ctx, name)
+	var opts []jenkins.ClientOption
+	if WantsQuiet(cmd) {
+		opts = append(opts, jenkins.WithDisableWarn(true))
+	}
+
+	return f.Client(ctx, name, opts...)
 }

--- a/pkg/cmd/shared/shared_test.go
+++ b/pkg/cmd/shared/shared_test.go
@@ -9,6 +9,63 @@ import (
 	"github.com/avivsinai/jenkins-cli/internal/config"
 )
 
+func TestWantsQuiet(t *testing.T) {
+	newRootWithChild := func() (*cobra.Command, *cobra.Command) {
+		root := &cobra.Command{Use: "jk"}
+		root.PersistentFlags().BoolP("quiet", "q", false, "Suppress non-essential output")
+		child := &cobra.Command{Use: "run"}
+		root.AddCommand(child)
+		return root, child
+	}
+
+	tests := []struct {
+		name  string
+		setup func(*testing.T, *cobra.Command)
+		want  bool
+	}{
+		{
+			name:  "returns false by default",
+			setup: nil,
+			want:  false,
+		},
+		{
+			name: "flag returns true",
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				t.Helper()
+				require.NoError(t, cmd.Root().PersistentFlags().Set("quiet", "true"))
+			},
+			want: true,
+		},
+		{
+			name: "env var returns true",
+			setup: func(t *testing.T, _ *cobra.Command) {
+				t.Helper()
+				t.Setenv("JK_QUIET", "1")
+			},
+			want: true,
+		},
+		{
+			name: "flag takes precedence over absent env",
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				t.Helper()
+				require.NoError(t, cmd.Root().PersistentFlags().Set("quiet", "true"))
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, child := newRootWithChild()
+			if tt.setup != nil {
+				tt.setup(t, child)
+			}
+			got := WantsQuiet(child)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestResolveContextNamePrecedence(t *testing.T) {
 	newConfig := func() *config.Config {
 		return &config.Config{

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -18,7 +18,7 @@ type Factory struct {
 	IOStreams *iostreams.IOStreams
 
 	Config        func() (*config.Config, error)
-	JenkinsClient func(context.Context, string) (*jenkins.Client, error)
+	JenkinsClient func(context.Context, string, ...jenkins.ClientOption) (*jenkins.Client, error)
 
 	once struct {
 		cfg sync.Once
@@ -54,14 +54,14 @@ func (f *Factory) Streams() (*iostreams.IOStreams, error) {
 }
 
 // Client returns a Jenkins client for the requested context.
-func (f *Factory) Client(ctx context.Context, contextName string) (*jenkins.Client, error) {
+func (f *Factory) Client(ctx context.Context, contextName string, opts ...jenkins.ClientOption) (*jenkins.Client, error) {
 	cfg, err := f.ResolveConfig()
 	if err != nil {
 		return nil, err
 	}
 
 	if f.JenkinsClient != nil {
-		return f.JenkinsClient(ctx, contextName)
+		return f.JenkinsClient(ctx, contextName, opts...)
 	}
-	return jenkins.NewClient(ctx, cfg, contextName)
+	return jenkins.NewClient(ctx, cfg, contextName, opts...)
 }

--- a/skills/jk/SKILL.md
+++ b/skills/jk/SKILL.md
@@ -365,6 +365,7 @@ jk run start team/app --quiet
 ## Environment Variables
 
 - `JK_CONTEXT` — Override active context
+- `JK_QUIET` — Equivalent to `--quiet` (any value enables)
 
 ## Exit Codes
 

--- a/skills/jk/references/commands.md
+++ b/skills/jk/references/commands.md
@@ -427,6 +427,7 @@ All commands support:
 ## Environment Variables
 
 - `JK_CONTEXT` — Override active context (empty = use config)
+- `JK_QUIET` — Equivalent to `--quiet` (any value enables)
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary

Closes #35

When using Jenkins over HTTP (not HTTPS), resty emits a `WARN` on every request:
```
WARN RESTY Using Basic Auth in HTTP mode is not secure, use HTTPS
```

Per review feedback, this PR wires the existing `--quiet`/`-q` global flag to also suppress resty HTTP client warnings via `WithDisableWarn(true)` — applied at client construction time, before any network calls.

```bash
jk -q run ls team/app/pipeline          # per-invocation
export JK_QUIET=1                        # permanent (add to shell profile)
```

## Design

- **Zero new config fields or flags** — leverages existing `--quiet`/`JK_QUIET`
- **Semantic fit** — resty warnings are "non-essential output" by definition
- **ClientOption pattern** — `WithDisableWarn` applied before `refreshCapabilities()` so no warnings leak during startup
- **Both resty clients covered** — option applies to both `resty` and `restyStream`
- **Consistent** — follows the existing `--quiet` precedent in `run start`/`run rerun`

## Changes

| File | Change |
|------|--------|
| `internal/jenkins/client.go` | Add `ClientOption` type, `WithDisableWarn(bool)` option; update `NewClient` to accept `...ClientOption` and apply before `refreshCapabilities()` |
| `internal/jenkins/client_test.go` | Add 6 tests: `WithDisableWarn` true/false/nil-stream, default no-disable, `SetDisableWarn` method, nil-stream safety |
| `pkg/cmdutil/factory.go` | Update `Factory.Client` to accept and forward `...jenkins.ClientOption` |
| `pkg/cmd/shared/shared.go` | Wire `WantsQuiet(cmd)` → `WithDisableWarn(true)` option passed at client construction time |
| `CHANGELOG.md` | Document `--quiet` now suppresses resty warnings |
| `docs/agent-cookbook.md` | Add tip for HTTP Jenkins warning suppression |

## Test plan

- [x] `make lint` — 0 issues
- [x] `JK_E2E_DISABLE=1 make test` — all tests pass
- [x] `TestWantsQuiet` — 4 subtests: default false, flag true, env true, precedence
- [x] `TestWithDisableWarn*` — 6 subtests: true/false/nil-stream/default/method/nil-safety
- [x] Manual: `jk -q run ls` on HTTP Jenkins suppresses resty warning
- [x] Manual: `JK_QUIET=1 jk run ls` permanently suppresses warning

## Review feedback addressed

| # | Feedback | Resolution |
|---|----------|------------|
| 1 | `--no-warnings` naming convention | Removed — using existing `--quiet` instead |
| 2 | `SetDisableWarn` timing (too late for `refreshCapabilities`) | Fixed — `WithDisableWarn` option applied inside `NewClient` before `refreshCapabilities()` fires any HTTP requests |
| 3 | Missing tests | Added `TestWantsQuiet` (4 subtests) + `TestWithDisableWarn*` (6 subtests) |
| 4 | Missing `docs/spec.md` | `--quiet` already in global flags (line 159); line 295 already documents warning suppression |
| 5 | `.agent-mail/` noise | Dropped from PR |
| 6 | CI gap | `make lint` (0 issues), `make test` (all pass) — verified locally |

🤖 Generated with [Claude Code](https://claude.com/claude-code)