### PR TITLE
fix: accept --with-meta on search commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `jk search` and `jk run search` now accept `--with-meta` as a compatibility alias, while the docs now explain that structured search output already includes lightweight metadata by default.
+
 ## [0.0.16] - 2026-02-25
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ main.go → jkcmd.Main() → root.NewCmdRoot(factory) → Cobra Execute()
 ## Agent Discovery Patterns
 
 When automating with `jk`:
-- `jk search --job-glob '*pattern*' --json --with-meta` for cross-folder job discovery
+- `jk search --job-glob '*pattern*' --json` for cross-folder job discovery
 - `jk run ls <job> --filter result=SUCCESS --since 7d --json` for filtered run queries
 - `jk run params <job>` to inspect parameter metadata before triggering builds
 - `jk help --json` for programmatic command enumeration

--- a/README.md
+++ b/README.md
@@ -114,13 +114,15 @@ Find jobs fast with `jk search` (alias for `jk run search`) before drilling into
 ```bash
 jk auth login https://jenkins.company.example      # authenticate and create a context
 jk context ls                                      # list available contexts
-jk search --job-glob '*deploy-*' --limit 5 --json --with-meta   # discover job paths across folders
+jk search --job-glob '*deploy-*' --limit 5 --json               # discover job paths across folders
 jk run ls team/app/pipeline --filter result=SUCCESS --since 7d --limit 5 --json --with-meta
 jk run ls team/app/pipeline --include-queued   # include queued builds (shown as qN)
 jk run params team/app/pipeline                    # inspect inferred parameter metadata
 jk run view team/app/pipeline 128 --follow         # stream logs until completion
 jk artifact download team/app/pipeline 128 -p "**/*.xml" -o out/
 ```
+
+Structured `jk search` output already includes lightweight search metadata; `--with-meta` is only needed for `jk run ls`.
 
 Add `--json`, `--yaml`, or `--format json|yaml` to supported commands for machine-readable output. Use `--jq` or `--template` to select or reshape JSON results.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -160,6 +160,8 @@ This document is normative for the Jenkins CLI (`jk`) JSON output modes and the 
 }
 ```
 
+Unlike `jk run ls`, structured search output always includes this lightweight `metadata` block. `--with-meta` is accepted for CLI compatibility, but it is not required.
+
 ### 2.4 Progressive log pointer (`/jk/api/runs/<jobPath>/<build>/logs`)
 ```json
 {

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -269,6 +269,7 @@ Key workflows the CLI must make trivial:
   - `--folder` to anchor discovery.
   - `--job-glob` (doublestar) to limit jobs by name/path.
   - `--max-scan` to cap runs inspected per job (default 500).
+- `--with-meta` is accepted for CLI parity with `jk run ls`, but structured search output already includes its lightweight metadata block without requiring the flag.
 - Results are sorted by start time descending and returned as `schemaVersion: 1.0` documents with `items[]` and lightweight metadata (`folder`, `jobGlob`, `filters`, `jobsScanned`, `selection`). Each item includes `jobPath`, `number`, `status/result`, duration, timestamps, optional SCM, and any selected `fields{}`.
 - Human output prints `jobPath	#<run>	RESULT	start	elapsed` per match; structured output enables agents to fan out without scraping.
 

--- a/pkg/cmd/run/search.go
+++ b/pkg/cmd/run/search.go
@@ -54,6 +54,7 @@ func NewCmdRunSearch(f *cmdutil.Factory) *cobra.Command {
 		limit       int
 		maxScan     int
 		selectArg   string
+		withMeta    bool
 		enableRegex bool
 	)
 
@@ -154,6 +155,7 @@ func NewCmdRunSearch(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().IntVar(&limit, "limit", defaultSearchLimit, "Max results to return")
 	cmd.Flags().IntVar(&maxScan, "max-scan", defaultSearchMaxScan, "Max builds to scan per job")
 	cmd.Flags().StringVar(&selectArg, "select", "", "Select additional fields (comma-separated)")
+	cmd.Flags().BoolVar(&withMeta, "with-meta", false, "Compatibility alias; structured search output already includes metadata")
 	cmd.Flags().BoolVar(&enableRegex, "regex", false, "Enable regular expression matching for filters")
 
 	return cmd

--- a/pkg/cmd/run/search_test.go
+++ b/pkg/cmd/run/search_test.go
@@ -3,6 +3,10 @@ package run
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/avivsinai/jenkins-cli/pkg/cmdutil"
 )
 
 func TestMatchJobGlob(t *testing.T) {
@@ -148,4 +152,15 @@ func TestPerformFuzzySearchEmptyQuery(t *testing.T) {
 	if got := performFuzzySearch("", allJobs, 5); got != nil {
 		t.Fatalf("expected nil results for empty query, got %v", got)
 	}
+}
+
+func TestNewCmdRunSearchAcceptsWithMetaFlag(t *testing.T) {
+	cmd := NewCmdRunSearch(&cmdutil.Factory{})
+
+	flag := cmd.Flags().Lookup("with-meta")
+	require.NotNil(t, flag, "with-meta compatibility flag should exist")
+	require.Equal(t, "bool", flag.Value.Type())
+
+	require.NoError(t, cmd.Flags().Parse([]string{"--with-meta"}))
+	require.Equal(t, "true", flag.Value.String())
 }


### PR DESCRIPTION
## Summary
- accept `--with-meta` on `jk search` and `jk run search` as a compatibility alias
- correct the public docs to explain that structured search output already includes lightweight metadata by default
- add regression coverage for the restored flag surface

## Root cause
The quickstart and agent docs advertised `jk search ... --with-meta`, but the search commands never defined that flag even though search JSON already returned a metadata block. That made the documented command fail with `unknown flag`.

## Impact
Users on current releases no longer hit a hard CLI error when following the documented search examples, and the docs now describe the actual search contract clearly.

## Validation
- `go test ./pkg/cmd/run -run 'TestNewCmdRunSearchAcceptsWithMetaFlag|TestMatchJobGlob|TestPerformFuzzySearch'`
- `go run ./cmd/jk search --help`
- `go run ./cmd/jk run search --help`
- `make build`
- `make test`

Closes #40
