### PR TITLE
chore: align skill manifests with v0.0.19

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jk",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "GitHub CLI-style interface for Jenkins controllers - manage jobs, pipelines, runs, logs, artifacts, credentials, and nodes",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jk",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "GitHub CLI-style interface for Jenkins controllers - manage jobs, pipelines, runs, logs, artifacts, credentials, and nodes",
   "author": {
     "name": "Aviv Sinai",

--- a/skills/jk/SKILL.md
+++ b/skills/jk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jk
-version: 0.0.18
+version: 0.0.19
 description: Jenkins CLI for controllers. Use when users need to manage jobs, pipelines, runs, logs, artifacts, credentials, nodes, or queues in Jenkins. Triggers include "jenkins", "jk", "pipeline", "build", "run logs", "job list", "jenkins credentials", "jenkins node".
 metadata:
   short-description: Jenkins CLI for jobs, pipelines, runs


### PR DESCRIPTION
## Summary
- bump the `jk` skill version to `0.0.19`
- align both plugin manifests with the same release version
- capture the metadata fix that was required after the `v0.0.19` tag had already been pushed

## Root cause
The `v0.0.19` tag was cut before the skill and plugin manifest versions were updated from `0.0.18`, which caused the tag-triggered `Publish Skills` workflow to fail its version check.

## Validation
- verified the three versioned files now all read `0.0.19`
- manually dispatched `Publish Skills` with `version=0.0.19` against this branch and confirmed success (`run 23792447682`)
