### PR TITLE
fix: skip nil rerun parameters

### DIFF
--- a/pkg/cmd/run/format.go
+++ b/pkg/cmd/run/format.go
@@ -390,6 +390,9 @@ func collectRerunParameters(detail runDetail) map[string]string {
 
 	out := make(map[string]string, len(params))
 	for _, param := range params {
+		if param.Value == nil {
+			continue
+		}
 		out[param.Name] = fmt.Sprint(param.Value)
 	}
 	return out

--- a/pkg/cmd/run/format_test.go
+++ b/pkg/cmd/run/format_test.go
@@ -1,0 +1,45 @@
+package run
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectRerunParametersSkipsNilValues(t *testing.T) {
+	detail := runDetail{
+		Parameters: []map[string]any{
+			{"name": "STRING_VALUE", "value": "hello"},
+			{"name": "BOOL_VALUE", "value": true},
+			{"name": "NIL_VALUE", "value": nil},
+		},
+	}
+
+	got := collectRerunParameters(detail)
+
+	require.Equal(t, map[string]string{
+		"STRING_VALUE": "hello",
+		"BOOL_VALUE":   "true",
+	}, got)
+	require.NotContains(t, got, "NIL_VALUE")
+}
+
+func TestCollectRerunParametersUsesActionParametersWhenNeeded(t *testing.T) {
+	detail := runDetail{
+		Actions: []map[string]any{
+			{
+				"parameters": []any{
+					map[string]any{"name": "FROM_ACTION", "value": "build#42"},
+					map[string]any{"name": "EMPTY_RUN_PARAM", "value": nil},
+				},
+			},
+		},
+	}
+
+	got := collectRerunParameters(detail)
+
+	require.Equal(t, map[string]string{
+		"FROM_ACTION": "build#42",
+	}, got)
+	require.NotContains(t, got, "EMPTY_RUN_PARAM")
+}


### PR DESCRIPTION
Avoid serializing missing rerun parameter values into the literal string "<nil>". This keeps rerun payloads compatible with Jenkins jobs that define optional run parameters.
