### PR TITLE
chore(release): v0.0.27

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jk",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "GitHub CLI-style interface for Jenkins controllers - manage jobs, pipelines, runs, logs, artifacts, credentials, and nodes",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jk",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "GitHub CLI-style interface for Jenkins controllers - manage jobs, pipelines, runs, logs, artifacts, credentials, and nodes",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.27] - 2026-04-02
 ### Fixed
 - Wrote generated GitHub release notes to the runner temp directory so GoReleaser can publish without dirtying the checked-out tree.
+
 
 ## [0.0.26] - 2026-04-02
 ### Changed

--- a/skills/jk/SKILL.md
+++ b/skills/jk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jk
-version: 0.0.26
+version: 0.0.27
 description: Jenkins CLI for controllers. Use when users need to manage jobs, pipelines, runs, logs, artifacts, credentials, nodes, or queues in Jenkins. Triggers include "jenkins", "jk", "pipeline", "build", "run logs", "job list", "jenkins credentials", "jenkins node".
 metadata:
   short-description: Jenkins CLI for jobs, pipelines, runs


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.0.27`
- aligns skill/plugin metadata to `0.0.27`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.0.27`, and publishes the release
- the skill publish workflow runs from the CI-created tag