### PR TITLE
fix(deps): add 7-day cooldown to Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,9 @@ updates:
           - "*"
     # Vendor dependencies (uncomment if using vendor/)
     # vendor: true
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -47,3 +50,6 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14


### PR DESCRIPTION
## Summary
- Add `cooldown` block (7-day default, 14-day semver-major) to both gomod and github-actions ecosystem entries
- Security updates (known CVEs) bypass cooldowns automatically

## Test plan
- [ ] Verify dependabot.yml is valid YAML and GitHub parses it correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)