### PR TITLE
chore(release): v0.0.29

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jk",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "GitHub CLI-style interface for Jenkins controllers - manage jobs, pipelines, runs, logs, artifacts, credentials, and nodes",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jk",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "GitHub CLI-style interface for Jenkins controllers - manage jobs, pipelines, runs, logs, artifacts, credentials, and nodes",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.29] - 2026-04-05
 ### Fixed
 - Consolidated skill publishing into the release workflow so it no longer depends on tag-push events that `GITHUB_TOKEN` cannot trigger.
 - Pinned all GitHub Actions to commit SHAs across every workflow for supply-chain safety.
 - Added missing `timeout-minutes` and `concurrency` blocks to all workflows.
 - Standalone publish-skill workflow now accepts `workflow_dispatch` with an explicit `tag` input.
+
 
 ## [0.0.28] - 2026-04-02
 ### Fixed

--- a/skills/jk/SKILL.md
+++ b/skills/jk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jk
-version: 0.0.28
+version: 0.0.29
 description: Jenkins CLI for controllers. Use when users need to manage jobs, pipelines, runs, logs, artifacts, credentials, nodes, or queues in Jenkins. Triggers include "jenkins", "jk", "pipeline", "build", "run logs", "job list", "jenkins credentials", "jenkins node".
 metadata:
   short-description: Jenkins CLI for jobs, pipelines, runs


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.0.29`
- aligns skill/plugin metadata to `0.0.29`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.0.29`, publishes the release, and publishes skills