### PR TITLE
chore(release): v0.0.30

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jk",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "GitHub CLI-style interface for Jenkins controllers - create multibranch jobs, inspect config.xml, and manage runs, logs, artifacts, credentials, nodes, and queues",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jk",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "GitHub CLI-style interface for Jenkins controllers - create multibranch jobs, inspect config.xml, and manage runs, logs, artifacts, credentials, nodes, and queues",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.30] - 2026-04-07
 ### Fixed
 - Skipped nil parameter values in rerun payloads so optional Jenkins parameters are no longer serialized as the literal string `<nil>` (#46).
 - Rendered nil parameter values as empty string instead of `<nil>` in human-readable `jk run view` output (#59).
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bumped `github.com/itchyny/gojq` from 0.12.18 to 0.12.19 (bugfixes + regexp caching performance) (#58).
 - Bumped `actions/setup-node` from 4.4.0 to 6.3.0 in CI workflows (#57).
+
 
 ## [0.0.29] - 2026-04-05
 

--- a/skills/jk/SKILL.md
+++ b/skills/jk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jk
-version: 0.0.29
+version: 0.0.30
 description: Jenkins CLI for controllers. Use when users need to manage jobs, pipelines, config.xml, runs, logs, artifacts, credentials, nodes, or queues in Jenkins. Triggers include "jenkins", "jk", "pipeline", "build", "job create", "job config", "config.xml", "run logs", "jenkins credentials", "jenkins node".
 metadata:
   short-description: Jenkins CLI for jobs, config, pipelines, runs


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.0.30`
- aligns skill/plugin metadata to `0.0.30`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.0.30`, publishes the release, and publishes skills