### PR TITLE
chore(release): v0.0.31

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jk",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "GitHub CLI-style interface for Jenkins controllers - create multibranch jobs, inspect config.xml, and manage runs, logs, artifacts, credentials, nodes, and queues",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jk",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "GitHub CLI-style interface for Jenkins controllers - create multibranch jobs, inspect config.xml, and manage runs, logs, artifacts, credentials, nodes, and queues",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.0.31] - 2026-04-24
 ### Fixed
 - macOS Keychain "Always Allow" now survives `brew upgrade jk`. The release codesign script pins the Designated Requirement to the bundle identifier (`-r='designated => identifier "..."'`) instead of letting it default to the cdhash, which changes on every build. This mirrors the fix shipped in `bitbucket-cli` for the same underlying issue.
 - Token saves on macOS now delete any stale Keychain item before writing, so the new entry is created with the current binary's DR instead of inheriting an ACL from a previous jk build. Re-run `jk auth login` once after upgrading to benefit.
 - macOS Keychain items created by jk now set `KeychainTrustApplication` on darwin, so fresh items trust the calling binary at create time instead of prompting on every access. `KeychainAccessibleWhenUnlocked` is set alongside for forward compatibility (currently a no-op on the file-based Keychain path 99designs/keyring uses).
 - Widened `secret.Store.Delete` to treat `os.ErrNotExist` as success so the encrypted file backend matches Keychain semantics.
+
 
 ## [0.0.30] - 2026-04-07
 ### Fixed

--- a/skills/jk/SKILL.md
+++ b/skills/jk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jk
-version: 0.0.30
+version: 0.0.31
 description: Jenkins CLI for controllers. Use when users need to manage jobs, pipelines, config.xml, runs, logs, artifacts, credentials, nodes, or queues in Jenkins. Triggers include "jenkins", "jk", "pipeline", "build", "job create", "job config", "config.xml", "run logs", "jenkins credentials", "jenkins node".
 metadata:
   short-description: Jenkins CLI for jobs, config, pipelines, runs


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.0.31`
- aligns skill/plugin metadata to `0.0.31`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.0.31`, publishes the release, and publishes skills