### PR TITLE
docs: add 0.0.33 changelog notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Removed the accidentally committed root-level `jk` binary and added a repository hygiene CI check to prevent it from returning (#79).
+- Checked the Darwin keychain lock file close error so local macOS lint is clean (#79).
 
 ## [0.0.32] - 2026-04-24
 ### Added


### PR DESCRIPTION
## Summary
- add Unreleased changelog entries for the root `jk` binary cleanup and Darwin lint fix

## Verification
- `git diff --check`