### PR TITLE
docs: document Jenkins SSO API token workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ jk run view team/app/pipeline 128 --follow         # stream logs until completio
 jk artifact download team/app/pipeline 128 -p "**/*.xml" -o out/
 ```
 
+### Jenkins SSO / Google OAuth
+
+`jk` uses Jenkins API tokens for scripted clients. If your controller uses Google OAuth, OpenID Connect, Okta, Azure AD, or another browser-based SSO realm, sign in to Jenkins in the browser first, open `/me/configure`, create a Jenkins API token, then run:
+
+```bash
+jk auth login https://jenkins.company.example --username you@example.com --token <JENKINS_API_TOKEN>
+```
+
+Use your Jenkins user ID for `--username`; for Google/OIDC setups this is usually your email address. Do not paste a Google OAuth access token into `--token` — Jenkins REST calls expect a Jenkins API token.
+
 Structured `jk search` output already includes lightweight search metadata; `--with-meta` is only needed for `jk run ls`.
 
 Add `--json`, `--yaml`, or `--format json|yaml` to supported commands for machine-readable output. Use `--jq` or `--template` to select or reshape JSON results.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -14,7 +14,7 @@
 
 ### Confirmed baselines & policies
 - **Supported Jenkins versions:** full support for three maintained LTS lines at any time — baseline `2.361.4`, baseline + ~12 months, and current LTS — validated continuously in CI. Older LTS versions receive best-effort support only.
-- **Authentication:** v1.0 ships with API token + Basic auth. OIDC/SSO integrations are tracked for a post-v1.0 iteration.
+- **Authentication:** v1.0 ships with Jenkins API token + Basic auth, which is also the supported scripted-client path for Google/OIDC/SSO security realms. Browser/device OAuth login flows remain tracked for a post-v1.0 iteration.
 - **Air-gapped & FIPS:** provide offline bundles (binaries, checksums, trust store guidance) in v1.0. FIPS-compatible builds are planned for the 1.x roadmap once Go/toolchain support is validated.
 - **Proxy & CA handling:** support `--proxy`, `HTTPS_PROXY`/`NO_PROXY`, and `--ca-file`/`JK_CA_FILE`, with precedence `flag > env > context config`.
 - **Telemetry:** opt-in only (`jk analytics enable|disable` or `JK_ANALYTICS=1`). Payload is limited to command name, duration, exit code, and capability hash; never transmit URLs, tokens, or identifiers.
@@ -44,6 +44,7 @@ Key workflows the CLI must make trivial:
 ## 5. Functional Requirements
 - **Authentication & contexts**
   - `jk auth login <url>` stores API tokens and TLS settings.
+  - Google/OIDC/SSO users authenticate through Jenkins API tokens: sign in through the browser realm, create a token under `/me/configure`, and pass the Jenkins user ID (often email) with `--username`.
   - `jk context ls|use|rm`, `jk whoami`.
   - Optional `jk auth status` to show crumb/token health.
 - **Jobs & pipeline management**
@@ -162,7 +163,7 @@ Key workflows the CLI must make trivial:
 | Global flags   | `--context`, `--url`, `--token`, `--insecure`, `--json`, `--yaml`, `--format`, `--jq`, `--template`, `--quiet`, `--color=auto|always|never`, `--trace` | CLI resolves context precedence: flag > env > active context. |
 
 ### 9.2 Configuration & State
-- Config file `config.yaml` holds contexts (name, URL, username), toggles (color, pager).
+- Config file `config.yaml` holds contexts (name, URL, Jenkins user ID), toggles (color, pager).
 - Secrets (API tokens) stored in OS keychain via `go-keyring`; fallback encrypted file only when the user passes `--allow-insecure-store` and confirms interactively.
 - Proxy configuration precedence is `flag (--proxy) > environment (HTTPS_PROXY/HTTP_PROXY/NO_PROXY) > context config`. CLI also honors custom CA bundles via `--ca-file` and `JK_CA_FILE`.
 - Per-context cache directory stores crumb and small metadata (capabilities, plugin detection caches) with short TTL.
@@ -187,6 +188,7 @@ Key workflows the CLI must make trivial:
 2. Issue `GET /crumbIssuer/api/json` when performing first mutating request or crumb missing/expired.
 3. Attach version handshake headers to every request: `X-JK-Client: <semver>` and `X-JK-Features: <capabilities>` (comma-separated).
 4. All requests include `Authorization: Basic <user:token>` and `Content-Type` appropriate to method.
+   For Google/OIDC/SSO controllers, `<user>` is the Jenkins user ID (commonly the email address) and `<token>` is a Jenkins API token, not an upstream OAuth access token.
 5. Respect Jenkins CSRF configuration; if crumb endpoint 404, assume crumbs disabled.
 6. Retry on 401/403 once after refreshing crumb; propagate descriptive error if still failing.
 

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -41,6 +41,12 @@ type authLoginOptions struct {
 	allowInsecureStore bool
 }
 
+const (
+	usernameFlagHelp = "Jenkins user ID (Google/SSO users: usually your email)"
+	usernamePrompt   = "Username (Jenkins user ID, often your email)"
+	tokenPrompt      = "Jenkins API token"
+)
+
 func newAuthLoginCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &authLoginOptions{setActive: true}
 
@@ -58,7 +64,7 @@ func newAuthLoginCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.name, "name", "", "Context name (defaults to Jenkins hostname)")
-	cmd.Flags().StringVar(&opts.username, "username", "", "Jenkins username")
+	cmd.Flags().StringVar(&opts.username, "username", "", usernameFlagHelp)
 	cmd.Flags().StringVar(&opts.token, "token", "", "Jenkins API token")
 	cmd.Flags().BoolVar(&opts.insecure, "insecure", false, "Skip TLS certificate verification")
 	cmd.Flags().StringVar(&opts.proxy, "proxy", "", "Proxy URL for this context")
@@ -83,14 +89,14 @@ func runAuthLogin(cmd *cobra.Command, cfg *config.Config, opts *authLoginOptions
 
 	username := opts.username
 	if username == "" {
-		if username, err = terminal.Prompt("Username", ""); err != nil {
+		if username, err = terminal.Prompt(usernamePrompt, ""); err != nil {
 			return fmt.Errorf("read username: %w", err)
 		}
 	}
 
 	token := opts.token
 	if token == "" {
-		if token, err = terminal.PromptSecret("API token"); err != nil {
+		if token, err = terminal.PromptSecret(tokenPrompt); err != nil {
 			return fmt.Errorf("read token: %w", err)
 		}
 	}

--- a/pkg/cmd/auth/auth_test.go
+++ b/pkg/cmd/auth/auth_test.go
@@ -1,0 +1,24 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/avivsinai/jenkins-cli/pkg/cmdutil"
+)
+
+func TestAuthLoginUsernameHelpMentionsSSOUserID(t *testing.T) {
+	cmd := newAuthLoginCmd(&cmdutil.Factory{})
+
+	flag := cmd.Flags().Lookup("username")
+	require.NotNil(t, flag)
+	require.Contains(t, flag.Usage, "Jenkins user ID")
+	require.Contains(t, flag.Usage, "Google/SSO users")
+}
+
+func TestAuthLoginInteractivePromptsDisambiguateJenkinsCredentials(t *testing.T) {
+	require.Contains(t, usernamePrompt, "Jenkins user ID")
+	require.Contains(t, usernamePrompt, "email")
+	require.Equal(t, "Jenkins API token", tokenPrompt)
+}

--- a/skills/jk/SKILL.md
+++ b/skills/jk/SKILL.md
@@ -38,6 +38,9 @@ If the command fails or `jk` is not found, install it using one of these methods
 # Login with credentials
 jk auth login https://jenkins.example.com --username alice --token <API_TOKEN>
 
+# Login to a Jenkins controller that uses Google/OIDC/SSO in the browser
+jk auth login https://jenkins.example.com --username alice@example.com --token <JENKINS_API_TOKEN>
+
 # Login with custom context name
 jk auth login https://jenkins.example.com --name prod --username alice --token <TOKEN>
 
@@ -55,13 +58,15 @@ jk auth logout prod         # Logout from specific context
 
 Options for `auth login`:
 - `--name` — Context name (defaults to hostname)
-- `--username` — Jenkins username
-- `--token` — API token
+- `--username` — Jenkins user ID (Google/SSO users: usually your email)
+- `--token` — Jenkins API token
 - `--insecure` — Skip TLS verification
 - `--proxy` — Proxy URL
 - `--ca-file` — Custom CA bundle
 - `--set-active` — Set as active context (default: true)
 - `--allow-insecure-store` — Allow encrypted file fallback
+
+For Google OAuth, OpenID Connect, Okta, Azure AD, or other browser SSO security realms, first sign in to Jenkins in the browser and create a Jenkins API token from `/me/configure`. Use that Jenkins API token with `--token`; do not use a Google/OIDC access token.
 
 ## Contexts
 

--- a/skills/jk/references/commands.md
+++ b/skills/jk/references/commands.md
@@ -10,6 +10,9 @@ Complete command reference for `jk`. Run `jk <command> --help` for details.
 # Login with credentials
 jk auth login https://jenkins.example.com --username alice --token <API_TOKEN>
 
+# Login to a Jenkins controller that uses Google/OIDC/SSO in the browser
+jk auth login https://jenkins.example.com --username alice@example.com --token <JENKINS_API_TOKEN>
+
 # With context name
 jk auth login https://jenkins.example.com --name prod --username alice --token <TOKEN>
 
@@ -26,13 +29,15 @@ jk auth login https://jenkins.example.com --username alice --token <TOKEN> --all
 
 Options:
 - `--name` — Context name (defaults to hostname)
-- `--username` — Jenkins username
-- `--token` — API token
+- `--username` — Jenkins user ID (Google/SSO users: usually your email)
+- `--token` — Jenkins API token
 - `--insecure` — Skip TLS verification
 - `--proxy` — Proxy URL
 - `--ca-file` — Custom CA bundle path
 - `--set-active` — Set as active context (default: true)
 - `--allow-insecure-store` — Allow encrypted file fallback
+
+For Google OAuth, OpenID Connect, Okta, Azure AD, or other browser SSO security realms, first sign in to Jenkins in the browser and create a Jenkins API token from `/me/configure`. Use that Jenkins API token with `--token`; do not use a Google/OIDC access token.
 
 ### Status and Logout
 

--- a/skills/jk/rules/auth.md
+++ b/skills/jk/rules/auth.md
@@ -37,7 +37,7 @@ jk auth login <url> [flags]
 | `--proxy` |  | Proxy URL for this context |
 | `--set-active` |  | Set the context as active after login |
 | `--token` |  | Jenkins API token |
-| `--username` |  | Jenkins username |
+| `--username` |  | Jenkins user ID (Google/SSO users: usually your email) |
 
 ### Inherited Flags
 


### PR DESCRIPTION
## Summary
- clarify that Jenkins Google/OIDC/SSO browser realms still use Jenkins API tokens for scripted clients
- update `jk auth login` username/token wording to disambiguate Jenkins user IDs and Jenkins API tokens
- update README/spec/skill docs and regenerated auth rule docs

## Verification
- `make build`
- `JK_E2E_DISABLE=1 make test`
- `make check-generated-skill`
- `make lint`
- `git diff --check`

Refs #77