### PR TITLE
docs(changelog): populate [Unreleased] for v0.0.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Clarified `jk auth login` username/token wording and added README/docs/spec/skill sections walking Google/OIDC/SSO users through the Jenkins API token workflow (#82).
+- Bumped runtime dependencies: `github.com/mattn/go-isatty` 0.0.21 → 0.0.22 (Windows 7 pipe-name fix) and `github.com/rs/zerolog` 1.35.0 → 1.35.1 (restore `Err()` logging when `ErrorStackMarshaler` returns nil) (#75).
 
 ## [0.0.33] - 2026-05-11
 ### Fixed


### PR DESCRIPTION
## Summary
- Populate `CHANGELOG.md` `[Unreleased]` with the two user-visible changes since `v0.0.33`.
- Prerequisite for cutting `v0.0.34` via `./scripts/release.sh` (script requires non-empty `[Unreleased]`).

## Scope
Both entries under `### Changed`:
- #82 — `jk auth login` SSO wording + docs/spec/skill walkthrough for Google/OIDC/SSO realms
- #75 — runtime dependency bumps: `go-isatty` 0.0.21 → 0.0.22, `zerolog` 1.35.0 → 1.35.1

CI dependency bumps (#73, #74, #78) intentionally excluded — not user-visible.

## Test plan
- [x] Diff reviewed; no other CHANGELOG entries affected
- [ ] CI green