### PR TITLE
chore(release): v0.0.34

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jk",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "GitHub CLI-style interface for Jenkins controllers - create multibranch jobs, inspect config.xml, and manage runs, logs, artifacts, credentials, nodes, and queues",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jk",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "GitHub CLI-style interface for Jenkins controllers - create multibranch jobs, inspect config.xml, and manage runs, logs, artifacts, credentials, nodes, and queues",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.0.34] - 2026-05-13
 ### Changed
 - Clarified `jk auth login` username/token wording and added README/docs/spec/skill sections walking Google/OIDC/SSO users through the Jenkins API token workflow (#82).
 - Bumped runtime dependencies: `github.com/mattn/go-isatty` 0.0.21 → 0.0.22 (Windows 7 pipe-name fix) and `github.com/rs/zerolog` 1.35.0 → 1.35.1 (restore `Err()` logging when `ErrorStackMarshaler` returns nil) (#75).
+
 
 ## [0.0.33] - 2026-05-11
 ### Fixed

--- a/skills/jk/SKILL.md
+++ b/skills/jk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jk
-version: 0.0.33
+version: 0.0.34
 description: Jenkins CLI for controllers. Use when users need to manage jobs, pipelines, config.xml, runs, logs, artifacts, credentials, nodes, or queues in Jenkins. Triggers include "jenkins", "jk", "pipeline", "build", "job create", "job config", "config.xml", "run logs", "jenkins credentials", "jenkins node".
 metadata:
   short-description: Jenkins CLI for jobs, config, pipelines, runs


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.0.34`
- aligns skill/plugin metadata to `0.0.34`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.0.34`, publishes the release, and publishes skills