### PR TITLE
feat: verify auth login credentials and harden SSO/google-login support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `jk auth login` now verifies credentials against the controller (`/whoAmI/api/json`): definite rejections fail the login with SSO-aware guidance and restore the previous context, token, and active selection; unreachable controllers save unverified with a warning; `--no-verify` skips the check (#77).
 - Requests that get redirected to a sign-in page (Jenkins form login, `securityRealm/commenceLogin`, or identity-provider authorize endpoints) now fail with a clear "use a Jenkins API token" error instead of an HTML parse failure; other redirects, such as artifact downloads to object storage, are unaffected (#77).
 - End-to-end coverage proving Jenkins API tokens keep working when the controller uses the `google-login` SSO realm, and that password Basic auth fails with actionable guidance there (#77).
+- SSO auth guidance now tells users to capture the Jenkins user ID from browser `/whoAmI/api/json` when email/login fails, covering realms that use opaque provider IDs (#102).
 
 ### Fixed
+- `jk run view` and other JSON-decoding requests now fail on Jenkins non-2xx responses instead of printing zero-value data such as `Run #0 SUCCESS` after a 401/403/404 (#101).
 - Made `--allow-insecure-store` and `JK_ALLOW_INSECURE_STORE=1` select encrypted file storage directly instead of trying native Linux keyrings first, so SecretService/KWallet failures no longer block the requested file backend (#88, #89).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added a Codex plugin composer icon for marketplace display (#85).
+- `jk auth login` now verifies credentials against the controller (`/whoAmI/api/json`): definite rejections fail the login with SSO-aware guidance and restore the previous context, token, and active selection; unreachable controllers save unverified with a warning; `--no-verify` skips the check (#77).
+- Requests that get redirected to a sign-in page (Jenkins form login, `securityRealm/commenceLogin`, or identity-provider authorize endpoints) now fail with a clear "use a Jenkins API token" error instead of an HTML parse failure; other redirects, such as artifact downloads to object storage, are unaffected (#77).
+- End-to-end coverage proving Jenkins API tokens keep working when the controller uses the `google-login` SSO realm, and that password Basic auth fails with actionable guidance there (#77).
 
 ### Fixed
 - Made `--allow-insecure-store` and `JK_ALLOW_INSECURE_STORE=1` select encrypted file storage directly instead of trying native Linux keyrings first, so SecretService/KWallet failures no longer block the requested file backend (#88, #89).

--- a/README.md
+++ b/README.md
@@ -133,17 +133,17 @@ jk artifact download team/app/pipeline 128 -p "**/*.xml" -o out/
 `jk` uses Jenkins API tokens for scripted clients. If your controller uses Google OAuth, OpenID Connect, Okta, Azure AD, or another browser-based SSO realm, sign in to Jenkins in the browser first, open `/me/configure`, create a Jenkins API token, then run:
 
 ```bash
-jk auth login https://jenkins.company.example --username you@example.com --token <JENKINS_API_TOKEN>
+jk auth login https://jenkins.company.example --username <jenkins-user-id> --token <JENKINS_API_TOKEN>
 ```
 
-Use your Jenkins user ID for `--username`; for Google/OIDC setups this is usually your email address. Do not paste a Google OAuth access token into `--token` — Jenkins REST calls expect a Jenkins API token.
+Use your Jenkins user ID for `--username`. For many Google/OIDC setups that is your email address, but some SSO realms use an opaque provider ID instead. If you are unsure, sign in to Jenkins in the browser and open `<jenkins-url>/whoAmI/api/json`; use the returned `name` value. If it reports `anonymous`, sign in first. Do not paste a Google OAuth access token into `--token` — Jenkins REST calls expect a Jenkins API token.
 
 This works because Jenkins validates API tokens before consulting the security realm, so SSO realms such as the `google-login` plugin do not block token-based CLI access (covered by an end-to-end test against a google-login controller).
 
 `jk auth login` verifies the credentials against the controller before finishing:
 
 - On success it reports the authenticated user (`Logged in to <url> as <user>`).
-- If Jenkins rejects the credentials (or treats them as anonymous), the login fails and the previous context, token, and active-context selection are restored — a typo can't clobber a working login. The error explains the API-token workflow above.
+- If Jenkins rejects the credentials (or treats them as anonymous), the login fails and the previous context, token, and active-context selection are restored — a typo can't clobber a working login. The error explains the API-token workflow and points to the browser `whoAmI` check above.
 - If the request is redirected to a sign-in page (Jenkins form login, `securityRealm/commenceLogin`, or an external identity provider), `jk` reports that the request never authenticated instead of failing on an HTML response. The same detection applies to every `jk` command, so an expired token against an SSO-fronted controller produces an actionable error.
 - If the controller cannot be reached, the credentials are saved unverified with a warning. Use `--no-verify` to skip the check entirely (for example when bootstrapping configuration before the controller is up).
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ jk auth login https://jenkins.company.example --username you@example.com --token
 
 Use your Jenkins user ID for `--username`; for Google/OIDC setups this is usually your email address. Do not paste a Google OAuth access token into `--token` — Jenkins REST calls expect a Jenkins API token.
 
+This works because Jenkins validates API tokens before consulting the security realm, so SSO realms such as the `google-login` plugin do not block token-based CLI access (covered by an end-to-end test against a google-login controller).
+
+`jk auth login` verifies the credentials against the controller before finishing:
+
+- On success it reports the authenticated user (`Logged in to <url> as <user>`).
+- If Jenkins rejects the credentials (or treats them as anonymous), the login fails and the previous context, token, and active-context selection are restored — a typo can't clobber a working login. The error explains the API-token workflow above.
+- If the request is redirected to a sign-in page (Jenkins form login, `securityRealm/commenceLogin`, or an external identity provider), `jk` reports that the request never authenticated instead of failing on an HTML response. The same detection applies to every `jk` command, so an expired token against an SSO-fronted controller produces an actionable error.
+- If the controller cannot be reached, the credentials are saved unverified with a warning. Use `--no-verify` to skip the check entirely (for example when bootstrapping configuration before the controller is up).
+
+Service accounts cannot authenticate through a browser-based SSO realm like `google-login` — they never become Jenkins users, so they cannot hold API tokens. That setup requires a bearer-validating front door (Google IAP, a JWT filter, or similar) in front of Jenkins; support for bearer/front-door authentication is tracked in [issue #77](https://github.com/avivsinai/jenkins-cli/issues/77).
+
 ### Secret Storage
 
 By default, `jk` stores API tokens in the OS keychain. `--allow-insecure-store` or `JK_ALLOW_INSECURE_STORE=1` selects the encrypted file backend instead of trying native keyring backends. `KEYRING_BACKEND` remains an explicit backend override for advanced use.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -44,7 +44,7 @@ Key workflows the CLI must make trivial:
 ## 5. Functional Requirements
 - **Authentication & contexts**
   - `jk auth login <url>` stores API tokens and TLS settings, then verifies the credentials via `GET /whoAmI/api/json`: definite rejections (401/403, anonymous, or a redirect to a sign-in page) fail the login and restore the previous context/token/active selection; unreachable controllers save unverified with a warning; `--no-verify` skips the check.
-  - Google/OIDC/SSO users authenticate through Jenkins API tokens: sign in through the browser realm, create a token under `/me/configure`, and pass the Jenkins user ID (often email) with `--username`. Jenkins core validates API tokens before the security realm, so SSO realms (e.g. `google-login`) keep token-based CLI access working — verified by an e2e test that switches the harness controller to the google-login realm.
+  - Google/OIDC/SSO users authenticate through Jenkins API tokens: sign in through the browser realm, create a token under `/me/configure`, and pass the Jenkins user ID with `--username`. If the user ID is not known, open `/whoAmI/api/json` while signed in through the browser and use the returned `name` value; some SSO realms use an opaque provider ID rather than an email address. Jenkins core validates API tokens before the security realm, so SSO realms (e.g. `google-login`) keep token-based CLI access working — verified by an e2e test that switches the harness controller to the google-login realm.
   - `jk context ls|use|rm`, `jk whoami`.
   - Optional `jk auth status` to show crumb/token health.
 - **Jobs & pipeline management**
@@ -188,7 +188,7 @@ Key workflows the CLI must make trivial:
 2. Issue `GET /crumbIssuer/api/json` when performing first mutating request or crumb missing/expired.
 3. Attach version handshake headers to every request: `X-JK-Client: <semver>` and `X-JK-Features: <capabilities>` (comma-separated).
 4. All requests include `Authorization: Basic <user:token>` and `Content-Type` appropriate to method.
-   For Google/OIDC/SSO controllers, `<user>` is the Jenkins user ID (commonly the email address) and `<token>` is a Jenkins API token, not an upstream OAuth access token.
+   For Google/OIDC/SSO controllers, `<user>` is the Jenkins user ID from `/whoAmI/api/json` in a signed-in browser session and `<token>` is a Jenkins API token, not an upstream OAuth access token.
 5. Respect Jenkins CSRF configuration; if crumb endpoint 404, assume crumbs disabled.
 6. Retry on 401/403 once after refreshing crumb; propagate descriptive error if still failing.
 7. Abort redirect chains that lead to an interactive sign-in page (Jenkins `/login`/`/loginError`, `securityRealm/commenceLogin` on any host, or identity-provider authorize endpoints such as `accounts.google.com`) with a typed error and API-token guidance; the reported redirect target is sanitized to scheme+host+path. All other redirects (e.g. artifact downloads to object storage) follow normally, capped at 10 hops.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -43,8 +43,8 @@ Key workflows the CLI must make trivial:
 
 ## 5. Functional Requirements
 - **Authentication & contexts**
-  - `jk auth login <url>` stores API tokens and TLS settings.
-  - Google/OIDC/SSO users authenticate through Jenkins API tokens: sign in through the browser realm, create a token under `/me/configure`, and pass the Jenkins user ID (often email) with `--username`.
+  - `jk auth login <url>` stores API tokens and TLS settings, then verifies the credentials via `GET /whoAmI/api/json`: definite rejections (401/403, anonymous, or a redirect to a sign-in page) fail the login and restore the previous context/token/active selection; unreachable controllers save unverified with a warning; `--no-verify` skips the check.
+  - Google/OIDC/SSO users authenticate through Jenkins API tokens: sign in through the browser realm, create a token under `/me/configure`, and pass the Jenkins user ID (often email) with `--username`. Jenkins core validates API tokens before the security realm, so SSO realms (e.g. `google-login`) keep token-based CLI access working — verified by an e2e test that switches the harness controller to the google-login realm.
   - `jk context ls|use|rm`, `jk whoami`.
   - Optional `jk auth status` to show crumb/token health.
 - **Jobs & pipeline management**
@@ -191,6 +191,7 @@ Key workflows the CLI must make trivial:
    For Google/OIDC/SSO controllers, `<user>` is the Jenkins user ID (commonly the email address) and `<token>` is a Jenkins API token, not an upstream OAuth access token.
 5. Respect Jenkins CSRF configuration; if crumb endpoint 404, assume crumbs disabled.
 6. Retry on 401/403 once after refreshing crumb; propagate descriptive error if still failing.
+7. Abort redirect chains that lead to an interactive sign-in page (Jenkins `/login`/`/loginError`, `securityRealm/commenceLogin` on any host, or identity-provider authorize endpoints such as `accounts.google.com`) with a typed error and API-token guidance; the reported redirect target is sanitized to scheme+host+path. All other redirects (e.g. artifact downloads to object storage) follow normally, capped at 10 hops.
 
 ### 9.4 Output & UX
 - Human output includes concise tables or cards; use color when stdout is TTY.

--- a/hack/e2e/controller.Dockerfile
+++ b/hack/e2e/controller.Dockerfile
@@ -22,7 +22,7 @@ RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /t
   && ln -s /usr/local/go/bin/go /usr/local/bin/go \
   && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
-RUN jenkins-plugin-cli --plugins "workflow-aggregator git configuration-as-code junit job-dsl cloudbees-bitbucket-branch-source"
+RUN jenkins-plugin-cli --plugins "workflow-aggregator git configuration-as-code junit job-dsl cloudbees-bitbucket-branch-source google-login"
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 

--- a/internal/jenkins/client.go
+++ b/internal/jenkins/client.go
@@ -269,8 +269,54 @@ func (c *Client) SetDisableWarn(disable bool) {
 	}
 }
 
-// Do executes the request with crumb handling.
+// HTTPStatusError reports a Jenkins HTTP response outside the successful 2xx
+// range.
+type HTTPStatusError struct {
+	Method      string
+	Path        string
+	StatusCode  int
+	Status      string
+	BodySnippet string
+}
+
+func (e *HTTPStatusError) Error() string {
+	status := e.Status
+	if status == "" && e.StatusCode != 0 {
+		status = http.StatusText(e.StatusCode)
+	}
+	if status == "" {
+		status = "unexpected HTTP status"
+	}
+
+	var msg string
+	if e.Method != "" && e.Path != "" {
+		msg = fmt.Sprintf("%s %s: %s", strings.ToUpper(e.Method), e.Path, status)
+	} else {
+		msg = status
+	}
+	if e.BodySnippet != "" {
+		msg += ": " + e.BodySnippet
+	}
+	return msg
+}
+
+// Do executes the request with crumb handling and returns an error for HTTP
+// responses outside the successful 2xx range.
 func (c *Client) Do(req *resty.Request, method, path string, result interface{}) (*resty.Response, error) {
+	resp, err := c.DoRaw(req, method, path, result)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || resp.IsSuccess() {
+		return resp, nil
+	}
+	return resp, newHTTPStatusError(method, path, resp)
+}
+
+// DoRaw executes the request with crumb handling and returns the response
+// regardless of HTTP status. Use this only when the caller intentionally
+// branches on Jenkins status codes or response bodies.
+func (c *Client) DoRaw(req *resty.Request, method, path string, result interface{}) (*resty.Response, error) {
 	if result != nil {
 		req.SetResult(result)
 	}
@@ -280,6 +326,32 @@ func (c *Client) Do(req *resty.Request, method, path string, result interface{})
 		return nil, err
 	}
 	return resp, nil
+}
+
+func newHTTPStatusError(method, path string, resp *resty.Response) error {
+	return &HTTPStatusError{
+		Method:      method,
+		Path:        path,
+		StatusCode:  resp.StatusCode(),
+		Status:      resp.Status(),
+		BodySnippet: responseBodySnippet(resp),
+	}
+}
+
+func responseBodySnippet(resp *resty.Response) string {
+	if resp == nil {
+		return ""
+	}
+	body := strings.TrimSpace(resp.String())
+	if body == "" {
+		return ""
+	}
+	body = strings.Join(strings.Fields(body), " ")
+	const maxSnippet = 240
+	if len(body) > maxSnippet {
+		return body[:maxSnippet] + "..."
+	}
+	return body
 }
 
 func (c *Client) execute(req *resty.Request, method, path string, allowRetry bool) (*resty.Response, error) {

--- a/internal/jenkins/client.go
+++ b/internal/jenkins/client.go
@@ -44,6 +44,7 @@ type Client struct {
 	crumb            *crumbValue
 	crumbMu          sync.Mutex
 	crumbUnsupported bool
+	skipCapProbe     bool
 }
 
 // Capabilities captures Jenkins feature detection results.
@@ -85,6 +86,15 @@ func WithDisableWarn(disable bool) ClientOption {
 				c.restyStream.SetDisableWarn(true)
 			}
 		}
+	}
+}
+
+// WithSkipCapabilityProbe skips capability detection during construction.
+// Useful when the client is only needed for a single check (such as login
+// verification), where probe failures would add noise before the real result.
+func WithSkipCapabilityProbe() ClientOption {
+	return func(c *Client) {
+		c.skipCapProbe = true
 	}
 }
 
@@ -176,6 +186,13 @@ func NewClient(ctx context.Context, cfg *config.Config, contextName string, opts
 	restyStream := restyClient.Clone()
 	restyStream.SetTimeout(0)
 
+	// SetRedirectPolicy replaces http.Client.CheckRedirect, dropping Go's
+	// default 10-hop cap — FlexibleRedirectPolicy restores it. Applied to both
+	// clients explicitly rather than relying on Clone copying CheckRedirect.
+	ssoPolicy := ssoRedirectPolicy{base: parsedURL}
+	restyClient.SetRedirectPolicy(ssoPolicy, resty.FlexibleRedirectPolicy(maxRedirects))
+	restyStream.SetRedirectPolicy(ssoPolicy, resty.FlexibleRedirectPolicy(maxRedirects))
+
 	client := &Client{
 		resty:       restyClient,
 		restyStream: restyStream,
@@ -188,8 +205,10 @@ func NewClient(ctx context.Context, cfg *config.Config, contextName string, opts
 		opt(client)
 	}
 
-	if err := client.refreshCapabilities(ctx); err != nil {
-		log.L().Warn().Err(err).Msg("capability detection failed")
+	if !client.skipCapProbe {
+		if err := client.refreshCapabilities(ctx); err != nil {
+			log.L().Warn().Err(err).Msg("capability detection failed")
+		}
 	}
 
 	return client, nil
@@ -276,7 +295,7 @@ func (c *Client) execute(req *resty.Request, method, path string, allowRetry boo
 
 	resp, err := req.Execute(method, path)
 	if err != nil {
-		return nil, err
+		return nil, sanitizeRedirectError(err)
 	}
 
 	if allowRetry && needsCrumb(method) &&
@@ -315,7 +334,7 @@ func (c *Client) ensureCrumb(ctx context.Context) (*crumbValue, error) {
 	var result crumbResponse
 	resp, err := c.resty.R().SetContext(ctx).SetResult(&result).Get(crumbEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("fetch crumb: %w", err)
+		return nil, fmt.Errorf("fetch crumb: %w", sanitizeRedirectError(err))
 	}
 
 	switch resp.StatusCode() {
@@ -337,6 +356,29 @@ func (c *Client) clearCrumb() {
 	c.crumbMu.Lock()
 	defer c.crumbMu.Unlock()
 	c.crumb = nil
+}
+
+// WhoAmI describes how Jenkins authenticated the client's credentials.
+type WhoAmI struct {
+	Name          string   `json:"name"`
+	Authenticated bool     `json:"authenticated"`
+	Authorities   []string `json:"authorities"`
+}
+
+// WhoAmI asks Jenkins how the current credentials authenticate. The response
+// is returned alongside the parsed result so callers can classify non-2xx
+// statuses (401/403 versus transient server errors).
+func (c *Client) WhoAmI(ctx context.Context) (*WhoAmI, *resty.Response, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var out WhoAmI
+	resp, err := c.NewRequest().SetContext(ctx).SetResult(&out).Get("/whoAmI/api/json")
+	if err != nil {
+		return nil, nil, sanitizeRedirectError(err)
+	}
+	return &out, resp, nil
 }
 
 // Capabilities returns the cached capabilities, refreshing if stale.
@@ -370,7 +412,7 @@ func (c *Client) refreshCapabilities(ctx context.Context) error {
 	var status statusResponse
 	resp, err := c.resty.R().SetContext(ctx).SetResult(&status).Get("/jk/api/status")
 	if err != nil {
-		return fmt.Errorf("probe jk/api/status: %w", err)
+		return fmt.Errorf("probe jk/api/status: %w", sanitizeRedirectError(err))
 	}
 
 	caps := Capabilities{}

--- a/internal/jenkins/client_test.go
+++ b/internal/jenkins/client_test.go
@@ -1,7 +1,10 @@
 package jenkins
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
@@ -107,5 +110,56 @@ func TestSetDisableWarnNilStream(t *testing.T) {
 
 	if !restyDisableWarn(t, rc) {
 		t.Error("SetDisableWarn(true): expected resty DisableWarn=true, got false")
+	}
+}
+
+func TestDoRejectsNonSuccessWhenDecodingResult(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"number":123}`))
+	}))
+	defer server.Close()
+
+	c := &Client{resty: resty.New().SetBaseURL(server.URL)}
+
+	var out struct {
+		Number int `json:"number"`
+	}
+	resp, err := c.Do(c.NewRequest(), http.MethodGet, "/run/api/json", &out)
+
+	if err == nil {
+		t.Fatal("expected non-success response to return an error")
+	}
+	if resp == nil || resp.StatusCode() != http.StatusUnauthorized {
+		t.Fatalf("expected 401 response to be returned with the error, got %#v", resp)
+	}
+	if out.Number != 0 {
+		t.Fatalf("expected failed response not to populate result, got %d", out.Number)
+	}
+	if !strings.Contains(err.Error(), "401 Unauthorized") {
+		t.Fatalf("expected status in error, got %q", err.Error())
+	}
+}
+
+func TestDoRawPreservesNonSuccessResponseForStatusCallers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("missing"))
+	}))
+	defer server.Close()
+
+	c := &Client{resty: resty.New().SetBaseURL(server.URL)}
+
+	resp, err := c.DoRaw(c.NewRequest(), http.MethodGet, "/optional/api/json", nil)
+
+	if err != nil {
+		t.Fatalf("expected raw request to preserve 404 response without error, got %v", err)
+	}
+	if resp.StatusCode() != http.StatusNotFound {
+		t.Fatalf("expected 404 response, got %s", resp.Status())
+	}
+	if resp.String() != "missing" {
+		t.Fatalf("expected response body to remain available, got %q", resp.String())
 	}
 }

--- a/internal/jenkins/redirect.go
+++ b/internal/jenkins/redirect.go
@@ -38,8 +38,8 @@ func (p ssoRedirectPolicy) Apply(req *http.Request, _ []*http.Request) error {
 		"Controllers behind SSO (Google, OIDC, ...) still require a Jenkins API token for CLI access: "+
 		"sign in with your browser, create a token at %s/me/configure, then run "+
 		"'jk auth login %s --username <jenkins-user-id> --token <api-token>' "+
-		"(SSO user IDs are usually the full email address)",
-		ErrSSORedirect, sanitized.String(), baseDisplay, baseDisplay)
+		"(if you do not know the Jenkins user ID, open %s/whoAmI/api/json in the signed-in browser and use its name value)",
+		ErrSSORedirect, sanitized.String(), baseDisplay, baseDisplay, baseDisplay)
 }
 
 // sanitizeRedirectError unwraps the url.Error that net/http wraps around a

--- a/internal/jenkins/redirect.go
+++ b/internal/jenkins/redirect.go
@@ -1,0 +1,91 @@
+package jenkins
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ErrSSORedirect marks requests that Jenkins (or a proxy in front of it)
+// answered with a redirect to an interactive sign-in page instead of serving
+// the API call. For a CLI request that always means the credentials never
+// authenticated the request.
+var ErrSSORedirect = errors.New("redirected to a sign-in page")
+
+const maxRedirects = 10
+
+// ssoRedirectPolicy aborts redirect chains that lead to an interactive login
+// flow: the Jenkins form login, a security realm's SSO entry point
+// (securityRealm/commenceLogin), or an external identity provider's authorize
+// endpoint. All other redirects (artifact managers redirecting downloads to
+// object storage, for example) are followed normally.
+type ssoRedirectPolicy struct {
+	base *url.URL
+}
+
+func (p ssoRedirectPolicy) Apply(req *http.Request, _ []*http.Request) error {
+	if req.URL == nil || !isLoginRedirect(p.base, req.URL) {
+		return nil
+	}
+
+	// IdP redirects carry sensitive query parameters (state, client_id);
+	// report scheme+host+path only.
+	sanitized := url.URL{Scheme: req.URL.Scheme, Host: req.URL.Host, Path: req.URL.Path}
+	baseDisplay := strings.TrimSuffix(p.base.String(), "/")
+	return fmt.Errorf("%w (%s): the request was not authenticated. "+
+		"Controllers behind SSO (Google, OIDC, ...) still require a Jenkins API token for CLI access: "+
+		"sign in with your browser, create a token at %s/me/configure, then run "+
+		"'jk auth login %s --username <jenkins-user-id> --token <api-token>' "+
+		"(SSO user IDs are usually the full email address)",
+		ErrSSORedirect, sanitized.String(), baseDisplay, baseDisplay)
+}
+
+// sanitizeRedirectError unwraps the url.Error that net/http wraps around a
+// CheckRedirect failure: that wrapper echoes the full redirect target
+// including query parameters (IdP state, client_id), which must not reach
+// user output. The inner policy error is self-contained and sanitized.
+func sanitizeRedirectError(err error) error {
+	if err == nil || !errors.Is(err, ErrSSORedirect) {
+		return err
+	}
+	var uerr *url.Error
+	if errors.As(err, &uerr) && uerr.Err != nil && errors.Is(uerr.Err, ErrSSORedirect) {
+		return uerr.Err
+	}
+	return err
+}
+
+// isLoginRedirect reports whether target is an interactive sign-in URL when
+// reached from a Jenkins controller at base.
+func isLoginRedirect(base, target *url.URL) bool {
+	path := strings.ToLower(target.Path)
+
+	// SecurityRealm SSO entry point on any host: the configured Jenkins root
+	// URL may differ from the URL the client uses, so same-host matching is
+	// not enough.
+	if strings.Contains(path, "/securityrealm/commencelogin") {
+		return true
+	}
+
+	// External identity providers.
+	if strings.EqualFold(target.Hostname(), "accounts.google.com") {
+		return true
+	}
+	if strings.Contains(path, "/oauth2/") && strings.Contains(path, "authorize") {
+		return true
+	}
+
+	// Jenkins form login on the controller itself, anchored to its context
+	// path so /loginfoo or unrelated /login endpoints elsewhere do not match.
+	if strings.EqualFold(target.Host, base.Host) {
+		rel := strings.TrimPrefix(path, strings.ToLower(strings.TrimSuffix(base.Path, "/")))
+		switch strings.TrimSuffix(rel, "/") {
+		case "/login", "/loginerror":
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/jenkins/redirect_test.go
+++ b/internal/jenkins/redirect_test.go
@@ -89,6 +89,7 @@ func TestSSORedirectPolicyBlocksLoginRedirect(t *testing.T) {
 	sanitized := sanitizeRedirectError(err)
 	require.ErrorIs(t, sanitized, ErrSSORedirect)
 	require.Contains(t, sanitized.Error(), "/me/configure")
+	require.Contains(t, sanitized.Error(), "/whoAmI/api/json")
 	require.NotContains(t, sanitized.Error(), "from=", "query parameters must not be echoed")
 }
 

--- a/internal/jenkins/redirect_test.go
+++ b/internal/jenkins/redirect_test.go
@@ -1,0 +1,142 @@
+package jenkins
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func mustParse(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func TestIsLoginRedirect(t *testing.T) {
+	tests := []struct {
+		name   string
+		base   string
+		target string
+		want   bool
+	}{
+		{"commenceLogin same host", "http://jenkins.local:8080", "http://jenkins.local:8080/securityRealm/commenceLogin?from=%2Fapi%2Fjson", true},
+		{"commenceLogin cross host", "http://jenkins.local:8080", "http://other.example.com/securityRealm/commenceLogin", true},
+		{"commenceLogin under context path", "http://jenkins.local/jenkins", "http://jenkins.local/jenkins/securityRealm/commenceLogin", true},
+		{"form login same host", "http://jenkins.local:8080", "http://jenkins.local:8080/login?from=%2F", true},
+		{"form login trailing slash", "http://jenkins.local:8080", "http://jenkins.local:8080/login/", true},
+		{"loginError same host", "http://jenkins.local:8080", "http://jenkins.local:8080/loginError", true},
+		{"form login under context path", "http://jenkins.local/jenkins", "http://jenkins.local/jenkins/login", true},
+		{"login prefix does not match", "http://jenkins.local:8080", "http://jenkins.local:8080/loginfoo", false},
+		{"login outside context path does not match", "http://jenkins.local/jenkins", "http://jenkins.local/other/login", false},
+		{"login on other host does not match", "http://jenkins.local:8080", "http://files.example.com/login", false},
+		{"google accounts", "http://jenkins.local:8080", "https://accounts.google.com/o/oauth2/v2/auth?client_id=x", true},
+		{"okta authorize", "http://jenkins.local:8080", "https://corp.okta.com/oauth2/v1/authorize?state=x", true},
+		{"azure authorize", "http://jenkins.local:8080", "https://login.microsoftonline.com/tid/oauth2/v2.0/authorize", true},
+		{"s3 presigned artifact", "http://jenkins.local:8080", "https://bucket.s3.amazonaws.com/artifacts/build.tgz?X-Amz-Signature=abc", false},
+		{"same host api redirect", "http://jenkins.local:8080", "http://jenkins.local:8080/job/foo/api/json", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isLoginRedirect(mustParse(t, tt.base), mustParse(t, tt.target))
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func newRedirectTestClient(baseURL string) *resty.Client {
+	client := resty.New()
+	client.SetBaseURL(baseURL)
+	policy := ssoRedirectPolicy{base: mustParseNoT(baseURL)}
+	client.SetRedirectPolicy(policy, resty.FlexibleRedirectPolicy(maxRedirects))
+	return client
+}
+
+func mustParseNoT(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func TestSSORedirectPolicyBlocksLoginRedirect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/json":
+			http.Redirect(w, r, "/securityRealm/commenceLogin?from=%2Fapi%2Fjson", http.StatusFound)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := newRedirectTestClient(server.URL)
+	_, err := client.R().Get("/api/json")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSSORedirect)
+
+	// net/http's url.Error wrapper echoes the raw redirect target;
+	// sanitizeRedirectError (applied on every Client execution path) must
+	// strip it down to the self-contained policy error.
+	sanitized := sanitizeRedirectError(err)
+	require.ErrorIs(t, sanitized, ErrSSORedirect)
+	require.Contains(t, sanitized.Error(), "/me/configure")
+	require.NotContains(t, sanitized.Error(), "from=", "query parameters must not be echoed")
+}
+
+func TestSanitizeRedirectErrorPassthrough(t *testing.T) {
+	require.NoError(t, sanitizeRedirectError(nil))
+	plain := errors.New("boom")
+	require.Equal(t, plain, sanitizeRedirectError(plain))
+}
+
+func TestSSORedirectPolicyFollowsNonLoginRedirect(t *testing.T) {
+	storage := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("artifact-bytes"))
+	}))
+	defer storage.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, storage.URL+"/artifacts/build.tgz", http.StatusFound)
+	}))
+	defer server.Close()
+
+	client := newRedirectTestClient(server.URL)
+	resp, err := client.R().Get("/job/foo/artifact/build.tgz")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode())
+	require.Equal(t, "artifact-bytes", resp.String())
+}
+
+func TestSSORedirectPolicyPreservesRedirectCap(t *testing.T) {
+	var server *httptest.Server
+	hops := 0
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hops++
+		http.Redirect(w, r, fmt.Sprintf("/hop/%d", hops), http.StatusFound)
+	}))
+	defer server.Close()
+
+	client := newRedirectTestClient(server.URL)
+	_, err := client.R().Get("/hop/0")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stopped after 10 redirects")
+}
+
+func TestSSORedirectErrorSurvivesURLErrorWrapping(t *testing.T) {
+	policy := ssoRedirectPolicy{base: mustParseNoT("http://jenkins.local:8080")}
+	target, _ := http.NewRequest(http.MethodGet, "http://jenkins.local:8080/login", nil)
+	err := policy.Apply(target, nil)
+	require.ErrorIs(t, err, ErrSSORedirect)
+
+	wrapped := &url.Error{Op: "Get", URL: "http://jenkins.local:8080/api/json", Err: err}
+	require.True(t, errors.Is(wrapped, ErrSSORedirect))
+}

--- a/pkg/cmd/artifact/artifact.go
+++ b/pkg/cmd/artifact/artifact.go
@@ -187,7 +187,7 @@ func newArtifactDownloadCmd(f *cmdutil.Factory) *cobra.Command {
 					segs[i] = url.PathEscape(s)
 				}
 				artifactPath := base + "/" + strings.Join(segs, "/")
-				resp, err := client.Do(req, http.MethodGet, artifactPath, nil)
+				resp, err := client.DoRaw(req, http.MethodGet, artifactPath, nil)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"runtime"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/avivsinai/jenkins-cli/internal/config"
+	"github.com/avivsinai/jenkins-cli/internal/jenkins"
 	"github.com/avivsinai/jenkins-cli/internal/secret"
 	"github.com/avivsinai/jenkins-cli/internal/terminal"
 	"github.com/avivsinai/jenkins-cli/pkg/cmdutil"
@@ -39,6 +41,7 @@ type authLoginOptions struct {
 	caFile             string
 	setActive          bool
 	allowInsecureStore bool
+	noVerify           bool
 }
 
 const (
@@ -71,6 +74,7 @@ func newAuthLoginCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.caFile, "ca-file", "", "Custom CA bundle for TLS verification")
 	cmd.Flags().BoolVar(&opts.setActive, "set-active", true, "Set the context as active after login")
 	cmd.Flags().BoolVar(&opts.allowInsecureStore, "allow-insecure-store", false, "Allow encrypted file-based secret storage")
+	cmd.Flags().BoolVar(&opts.noVerify, "no-verify", false, "Skip credential verification against the controller")
 
 	return cmd
 }
@@ -111,6 +115,20 @@ func runAuthLogin(cmd *cobra.Command, cfg *config.Config, opts *authLoginOptions
 		return fmt.Errorf("open secret store: %w", err)
 	}
 
+	key := secret.TokenKey(contextName)
+
+	// Snapshot the pre-login state so a failed verification can restore it:
+	// a login with bad credentials must not replace a working context, token,
+	// or active-context selection.
+	var prevCtx *config.Context
+	if existing, ctxErr := cfg.Context(contextName); ctxErr == nil && existing != nil {
+		snapshot := *existing
+		prevCtx = &snapshot
+	}
+	prevActive := cfg.Active
+	prevToken, prevTokenErr := store.Get(key)
+	hadToken := prevTokenErr == nil
+
 	cfg.SetContext(contextName, &config.Context{
 		URL:                parsed.String(),
 		Username:           username,
@@ -130,8 +148,6 @@ func runAuthLogin(cmd *cobra.Command, cfg *config.Config, opts *authLoginOptions
 		return fmt.Errorf("save config: %w", err)
 	}
 
-	key := secret.TokenKey(contextName)
-
 	// On darwin, an existing Keychain item's ACL is preserved by the update
 	// path in 99designs/keyring (kcItem.SetAccess(nil) in updateItem). That
 	// means a stale ACL entry from a previous jk binary with a different
@@ -148,8 +164,97 @@ func runAuthLogin(cmd *cobra.Command, cfg *config.Config, opts *authLoginOptions
 		return fmt.Errorf("store token: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Logged in to %s (%s)\n", parsed.String(), contextName)
-	return nil
+	if opts.noVerify {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Logged in to %s (%s)\n", parsed.String(), contextName)
+		return nil
+	}
+
+	who, verifyErr := verifyLogin(cmd, cfg, contextName)
+	switch {
+	case verifyErr == nil:
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Logged in to %s as %s (%s)\n", parsed.String(), who.Name, contextName)
+		return nil
+	case errors.Is(verifyErr, errVerifyInconclusive):
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: %v; credentials saved unverified\n", verifyErr)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Logged in to %s (%s)\n", parsed.String(), contextName)
+		return nil
+	default:
+		rollbackLogin(cfg, store, contextName, key, prevCtx, prevActive, prevToken, hadToken)
+		return loginVerificationError(verifyErr, parsed, contextName, prevCtx != nil)
+	}
+}
+
+// errVerifyInconclusive marks verification outcomes where Jenkins could not
+// be reached or answered unexpectedly — distinct from a definite credential
+// rejection, which rolls the login back.
+var errVerifyInconclusive = errors.New("could not verify credentials")
+
+// verifyLogin asks Jenkins how the just-stored credentials authenticate.
+// A nil error means the credentials are valid. Errors wrapping
+// errVerifyInconclusive mean Jenkins could not be consulted; any other error
+// is a definite rejection.
+func verifyLogin(cmd *cobra.Command, cfg *config.Config, contextName string) (*jenkins.WhoAmI, error) {
+	ctx := cmd.Context()
+
+	client, err := jenkins.NewClient(ctx, cfg, contextName,
+		jenkins.WithSkipCapabilityProbe(), jenkins.WithDisableWarn(true))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errVerifyInconclusive, err)
+	}
+
+	who, resp, err := client.WhoAmI(ctx)
+	switch {
+	case err != nil && errors.Is(err, jenkins.ErrSSORedirect):
+		return nil, err
+	case err != nil:
+		return nil, fmt.Errorf("%w: %v", errVerifyInconclusive, err)
+	case resp.StatusCode() == http.StatusUnauthorized || resp.StatusCode() == http.StatusForbidden:
+		return nil, fmt.Errorf("jenkins rejected the credentials (%s)", resp.Status())
+	case resp.IsSuccess() && who.Authenticated:
+		return who, nil
+	case resp.IsSuccess():
+		return nil, errors.New("jenkins treated the request as anonymous")
+	default:
+		return nil, fmt.Errorf("%w: unexpected response %s", errVerifyInconclusive, resp.Status())
+	}
+}
+
+// rollbackLogin restores the pre-login context, token, and active-context
+// selection after a definite verification failure. Best effort: rollback
+// errors are not surfaced over the primary verification error.
+func rollbackLogin(cfg *config.Config, store *secret.Store, contextName, key string, prevCtx *config.Context, prevActive string, prevToken string, hadToken bool) {
+	if prevCtx != nil {
+		cfg.SetContext(contextName, prevCtx)
+	} else {
+		cfg.RemoveContext(contextName)
+	}
+	_ = cfg.SetActive(prevActive)
+	_ = cfg.Save()
+
+	if hadToken {
+		_ = store.Set(key, prevToken)
+	} else {
+		_ = store.Delete(key)
+	}
+}
+
+func loginVerificationError(verifyErr error, parsed *url.URL, contextName string, restored bool) error {
+	outcome := fmt.Sprintf("context %q was not saved", contextName)
+	if restored {
+		outcome = fmt.Sprintf("the previous configuration for context %q was restored", contextName)
+	}
+
+	// The SSO redirect error already carries full token guidance.
+	if errors.Is(verifyErr, jenkins.ErrSSORedirect) {
+		return fmt.Errorf("login verification failed: %w; %s", verifyErr, outcome)
+	}
+
+	base := strings.TrimSuffix(parsed.String(), "/")
+	return fmt.Errorf("login verification failed: %v; %s. "+
+		"Use a Jenkins API token (create one at %s/me/configure), not a password or SSO token; "+
+		"for Google/SSO realms the Jenkins user ID is usually the full email address. "+
+		"Use --no-verify to store credentials without checking them",
+		verifyErr, outcome, base)
 }
 
 func deriveContextName(u *url.URL) string {

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -45,8 +45,8 @@ type authLoginOptions struct {
 }
 
 const (
-	usernameFlagHelp = "Jenkins user ID (Google/SSO users: usually your email)"
-	usernamePrompt   = "Username (Jenkins user ID, often your email)"
+	usernameFlagHelp = "Jenkins user ID (SSO users: use browser /whoAmI/api/json if unsure)"
+	usernamePrompt   = "Username (Jenkins user ID; use browser /whoAmI name if unsure)"
 	tokenPrompt      = "Jenkins API token"
 )
 
@@ -252,9 +252,10 @@ func loginVerificationError(verifyErr error, parsed *url.URL, contextName string
 	base := strings.TrimSuffix(parsed.String(), "/")
 	return fmt.Errorf("login verification failed: %v; %s. "+
 		"Use a Jenkins API token (create one at %s/me/configure), not a password or SSO token; "+
-		"for Google/SSO realms the Jenkins user ID is usually the full email address. "+
+		"for SSO realms, sign in with your browser and open %s/whoAmI/api/json; use the returned name value as --username "+
+		"(if it says anonymous, sign in first). "+
 		"Use --no-verify to store credentials without checking them",
-		verifyErr, outcome, base)
+		verifyErr, outcome, base, base)
 }
 
 func deriveContextName(u *url.URL) string {

--- a/pkg/cmd/auth/auth_test.go
+++ b/pkg/cmd/auth/auth_test.go
@@ -25,12 +25,12 @@ func TestAuthLoginUsernameHelpMentionsSSOUserID(t *testing.T) {
 	flag := cmd.Flags().Lookup("username")
 	require.NotNil(t, flag)
 	require.Contains(t, flag.Usage, "Jenkins user ID")
-	require.Contains(t, flag.Usage, "Google/SSO users")
+	require.Contains(t, flag.Usage, "/whoAmI/api/json")
 }
 
 func TestAuthLoginInteractivePromptsDisambiguateJenkinsCredentials(t *testing.T) {
 	require.Contains(t, usernamePrompt, "Jenkins user ID")
-	require.Contains(t, usernamePrompt, "email")
+	require.Contains(t, usernamePrompt, "/whoAmI")
 	require.Equal(t, "Jenkins API token", tokenPrompt)
 }
 
@@ -105,6 +105,7 @@ func TestAuthLoginVerificationRejectedRollsBackNewContext(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "rejected")
 	require.Contains(t, err.Error(), "/me/configure")
+	require.Contains(t, err.Error(), "/whoAmI/api/json")
 
 	_, ctxErr := cfg.Context("t1")
 	require.ErrorIs(t, ctxErr, config.ErrContextNotFound)
@@ -242,6 +243,7 @@ func TestLoginVerificationErrorWithoutPriorContext(t *testing.T) {
 	err := loginVerificationError(errors.New("boom"), parsed, "ctx1", false)
 	require.Contains(t, err.Error(), `context "ctx1" was not saved`)
 	require.Contains(t, err.Error(), "http://jenkins.example.com/me/configure")
+	require.Contains(t, err.Error(), "http://jenkins.example.com/whoAmI/api/json")
 }
 
 func mustURL(t *testing.T, raw string) *url.URL {

--- a/pkg/cmd/auth/auth_test.go
+++ b/pkg/cmd/auth/auth_test.go
@@ -1,10 +1,21 @@
 package auth
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
+	"github.com/avivsinai/jenkins-cli/internal/config"
+	"github.com/avivsinai/jenkins-cli/internal/jenkins"
+	"github.com/avivsinai/jenkins-cli/internal/secret"
 	"github.com/avivsinai/jenkins-cli/pkg/cmdutil"
 )
 
@@ -21,4 +32,221 @@ func TestAuthLoginInteractivePromptsDisambiguateJenkinsCredentials(t *testing.T)
 	require.Contains(t, usernamePrompt, "Jenkins user ID")
 	require.Contains(t, usernamePrompt, "email")
 	require.Equal(t, "Jenkins API token", tokenPrompt)
+}
+
+// loginTestEnv sandboxes config (HOME / XDG_CONFIG_HOME) and the secret store
+// (encrypted file backend) into a temp directory.
+func loginTestEnv(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("KEYRING_BACKEND", "file")
+	t.Setenv("KEYRING_FILE_DIR", tmp+"/secrets")
+	t.Setenv("JK_ALLOW_INSECURE_STORE", "1")
+	t.Setenv("JK_KEYRING_PASSPHRASE", "test-pass")
+	t.Setenv("KEYRING_FILE_PASSWORD", "test-pass")
+}
+
+func newLoginCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetContext(context.Background())
+	return cmd, &out, &errOut
+}
+
+func openTestStore(t *testing.T) *secret.Store {
+	t.Helper()
+	store, err := secret.Open(secret.WithAllowFileFallback(true))
+	require.NoError(t, err)
+	return store
+}
+
+func TestAuthLoginVerificationSuccess(t *testing.T) {
+	loginTestEnv(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/whoAmI/api/json", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"admin","authenticated":true}`))
+	}))
+	defer server.Close()
+
+	cmd, out, _ := newLoginCmd(t)
+	cfg := &config.Config{}
+	opts := &authLoginOptions{name: "t1", username: "admin", token: "tok", setActive: true}
+
+	require.NoError(t, runAuthLogin(cmd, cfg, opts, server.URL))
+	require.Contains(t, out.String(), "as admin")
+
+	saved, err := cfg.Context("t1")
+	require.NoError(t, err)
+	require.Equal(t, server.URL, saved.URL)
+
+	got, err := openTestStore(t).Get(secret.TokenKey("t1"))
+	require.NoError(t, err)
+	require.Equal(t, "tok", got)
+}
+
+func TestAuthLoginVerificationRejectedRollsBackNewContext(t *testing.T) {
+	loginTestEnv(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	cmd, _, _ := newLoginCmd(t)
+	cfg := &config.Config{}
+	opts := &authLoginOptions{name: "t1", username: "admin", token: "bad", setActive: true}
+
+	err := runAuthLogin(cmd, cfg, opts, server.URL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "rejected")
+	require.Contains(t, err.Error(), "/me/configure")
+
+	_, ctxErr := cfg.Context("t1")
+	require.ErrorIs(t, ctxErr, config.ErrContextNotFound)
+	require.Empty(t, cfg.Active)
+
+	_, tokenErr := openTestStore(t).Get(secret.TokenKey("t1"))
+	require.ErrorIs(t, tokenErr, os.ErrNotExist)
+}
+
+func TestAuthLoginVerificationRejectedRestoresPreviousState(t *testing.T) {
+	loginTestEnv(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{}
+	cfg.SetContext("t1", &config.Context{URL: "http://old.example.com", Username: "old-user"})
+	require.NoError(t, cfg.SetActive("t1"))
+	require.NoError(t, openTestStore(t).Set(secret.TokenKey("t1"), "old-token"))
+
+	cmd, _, _ := newLoginCmd(t)
+	opts := &authLoginOptions{name: "t1", username: "admin", token: "bad", setActive: true}
+
+	err := runAuthLogin(cmd, cfg, opts, server.URL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "restored")
+
+	saved, ctxErr := cfg.Context("t1")
+	require.NoError(t, ctxErr)
+	require.Equal(t, "http://old.example.com", saved.URL)
+	require.Equal(t, "old-user", saved.Username)
+	require.Equal(t, "t1", cfg.Active)
+
+	got, tokenErr := openTestStore(t).Get(secret.TokenKey("t1"))
+	require.NoError(t, tokenErr)
+	require.Equal(t, "old-token", got)
+}
+
+func TestAuthLoginVerificationSSORedirectRollsBack(t *testing.T) {
+	loginTestEnv(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/whoAmI/api/json" {
+			http.Redirect(w, r, "/securityRealm/commenceLogin?from=%2F", http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cmd, _, _ := newLoginCmd(t)
+	cfg := &config.Config{}
+	opts := &authLoginOptions{name: "t1", username: "admin", token: "tok", setActive: true}
+
+	err := runAuthLogin(cmd, cfg, opts, server.URL)
+	require.Error(t, err)
+	require.ErrorIs(t, err, jenkins.ErrSSORedirect)
+	require.Contains(t, err.Error(), "/me/configure")
+	require.NotContains(t, err.Error(), "from=")
+
+	_, ctxErr := cfg.Context("t1")
+	require.ErrorIs(t, ctxErr, config.ErrContextNotFound)
+}
+
+func TestAuthLoginVerificationAnonymousRollsBack(t *testing.T) {
+	loginTestEnv(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"anonymous","authenticated":false}`))
+	}))
+	defer server.Close()
+
+	cmd, _, _ := newLoginCmd(t)
+	cfg := &config.Config{}
+	opts := &authLoginOptions{name: "t1", username: "admin", token: "tok", setActive: true}
+
+	err := runAuthLogin(cmd, cfg, opts, server.URL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "anonymous")
+
+	_, ctxErr := cfg.Context("t1")
+	require.ErrorIs(t, ctxErr, config.ErrContextNotFound)
+}
+
+func TestAuthLoginVerificationInconclusiveKeepsCredentials(t *testing.T) {
+	loginTestEnv(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cmd, out, errOut := newLoginCmd(t)
+	cfg := &config.Config{}
+	opts := &authLoginOptions{name: "t1", username: "admin", token: "tok", setActive: true}
+
+	require.NoError(t, runAuthLogin(cmd, cfg, opts, server.URL))
+	require.Contains(t, errOut.String(), "could not verify credentials")
+	require.Contains(t, out.String(), "Logged in to")
+
+	_, ctxErr := cfg.Context("t1")
+	require.NoError(t, ctxErr)
+}
+
+func TestAuthLoginNoVerifySkipsCheck(t *testing.T) {
+	loginTestEnv(t)
+
+	cmd, out, _ := newLoginCmd(t)
+	cfg := &config.Config{}
+	// Unreachable URL: --no-verify must not touch the network.
+	opts := &authLoginOptions{name: "t1", username: "admin", token: "tok", setActive: true, noVerify: true}
+
+	require.NoError(t, runAuthLogin(cmd, cfg, opts, "http://127.0.0.1:1"))
+	require.Contains(t, out.String(), "Logged in to")
+
+	_, ctxErr := cfg.Context("t1")
+	require.NoError(t, ctxErr)
+}
+
+func TestAuthLoginVerificationUnreachableIsInconclusive(t *testing.T) {
+	loginTestEnv(t)
+
+	cmd, _, errOut := newLoginCmd(t)
+	cfg := &config.Config{}
+	opts := &authLoginOptions{name: "t1", username: "admin", token: "tok", setActive: true}
+
+	require.NoError(t, runAuthLogin(cmd, cfg, opts, "http://127.0.0.1:1"))
+	require.Contains(t, errOut.String(), "could not verify credentials")
+
+	_, ctxErr := cfg.Context("t1")
+	require.NoError(t, ctxErr)
+}
+
+func TestLoginVerificationErrorWithoutPriorContext(t *testing.T) {
+	parsed := mustURL(t, "http://jenkins.example.com")
+	err := loginVerificationError(errors.New("boom"), parsed, "ctx1", false)
+	require.Contains(t, err.Error(), `context "ctx1" was not saved`)
+	require.Contains(t, err.Error(), "http://jenkins.example.com/me/configure")
+}
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
 }

--- a/pkg/cmd/cred/cred.go
+++ b/pkg/cmd/cred/cred.go
@@ -132,7 +132,7 @@ func fetchFromJKAPI(client *jenkins.Client, scope, folder string) (*credentialsL
 	}
 
 	var resp jkCredentialList
-	httpResp, err := client.Do(req, http.MethodGet, "/jk/api/credentials", &resp)
+	httpResp, err := client.DoRaw(req, http.MethodGet, "/jk/api/credentials", &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func fetchFromCoreAPI(client *jenkins.Client, scope, folder string) (*credential
 	}
 
 	var core coreCredentialsResponse
-	resp, err := client.Do(client.NewRequest().SetQueryParam("tree", "credentials[id,typeName,displayName,description]"), http.MethodGet, targetPath, &core)
+	resp, err := client.DoRaw(client.NewRequest().SetQueryParam("tree", "credentials[id,typeName,displayName,description]"), http.MethodGet, targetPath, &core)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +251,7 @@ func newCredCreateSecretCmd(f *cmdutil.Factory) *cobra.Command {
 				},
 			}
 
-			resp, err := client.Do(client.NewRequest().SetBody(body), http.MethodPost, path, nil)
+			resp, err := client.DoRaw(client.NewRequest().SetBody(body), http.MethodPost, path, nil)
 			if err != nil {
 				return err
 			}
@@ -310,7 +310,7 @@ func newCredDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			path := fmt.Sprintf("%s/%s/doDelete", base, url.PathEscape(credentialID))
-			resp, err := client.Do(client.NewRequest(), http.MethodPost, path, nil)
+			resp, err := client.DoRaw(client.NewRequest(), http.MethodPost, path, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/job/config.go
+++ b/pkg/cmd/job/config.go
@@ -231,7 +231,7 @@ func fetchJobConfigXML(ctx context.Context, client *jenkins.Client, jobPath stri
 		return "", err
 	}
 
-	resp, err := client.Do(
+	resp, err := client.DoRaw(
 		client.NewRequest().
 			SetContext(ctx).
 			SetHeader("Accept", "application/xml"),
@@ -257,7 +257,7 @@ func updateJobConfigXML(ctx context.Context, client *jenkins.Client, jobPath, co
 		return errors.New("config.xml payload cannot be empty")
 	}
 
-	resp, err := client.Do(
+	resp, err := client.DoRaw(
 		client.NewRequest().
 			SetContext(ctx).
 			SetHeader("Accept", "application/xml").
@@ -334,7 +334,7 @@ func triggerJobScan(ctx context.Context, client *jenkins.Client, jobPath string)
 		return nil, errors.New("job path is required")
 	}
 
-	resp, err := client.Do(
+	resp, err := client.DoRaw(
 		client.NewRequest().
 			SetContext(ctx).
 			SetHeader("Content-Type", "application/x-www-form-urlencoded").

--- a/pkg/cmd/job/create.go
+++ b/pkg/cmd/job/create.go
@@ -163,7 +163,7 @@ func createMultibranchBitbucketJob(ctx context.Context, client *jenkins.Client, 
 		SetQueryParam("name", spec.Name).
 		SetQueryParam("mode", workflowMultiBranchMode)
 
-	resp, err := client.Do(createReq, http.MethodPost, createPath, nil)
+	resp, err := client.DoRaw(createReq, http.MethodPost, createPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create multibranch project: %w", err)
 	}
@@ -174,7 +174,7 @@ func createMultibranchBitbucketJob(ctx context.Context, client *jenkins.Client, 
 	jobPath := fullJobPath(spec.Folder, spec.Name)
 	configPath := fmt.Sprintf("/%s/config.xml", jenkins.EncodeJobPath(jobPath))
 
-	configResp, err := client.Do(
+	configResp, err := client.DoRaw(
 		client.NewRequest().
 			SetContext(ctx).
 			SetHeader("Accept", "application/xml"),
@@ -194,7 +194,7 @@ func createMultibranchBitbucketJob(ctx context.Context, client *jenkins.Client, 
 		return nil, fmt.Errorf("prepare config.xml for %s: %w", jobPath, err)
 	}
 
-	updateResp, err := client.Do(
+	updateResp, err := client.DoRaw(
 		client.NewRequest().
 			SetContext(ctx).
 			SetHeader("Accept", "application/xml").

--- a/pkg/cmd/log/log.go
+++ b/pkg/cmd/log/log.go
@@ -91,12 +91,15 @@ func runLog(cmd *cobra.Command, f *cmdutil.Factory, opts *logOptions) error {
 
 	path := fmt.Sprintf("/%s/%d/api/json", encoded, num)
 	detail := &runDetail{}
-	resp, err := client.Do(client.NewRequest(), http.MethodGet, path, detail)
+	resp, err := client.DoRaw(client.NewRequest(), http.MethodGet, path, detail)
 	if err != nil {
 		return err
 	}
 	if resp.StatusCode() == http.StatusNotFound {
 		return shared.NewExitError(3, fmt.Sprintf("run %s #%d not found", opts.jobPath, num))
+	}
+	if resp.StatusCode() >= 400 {
+		return fmt.Errorf("view run %s #%d: %s", opts.jobPath, num, resp.Status())
 	}
 
 	status := statusFromFlags(detail.Building)

--- a/pkg/cmd/node/node.go
+++ b/pkg/cmd/node/node.go
@@ -145,7 +145,7 @@ func newNodeDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			path := fmt.Sprintf("/computer/%s/doDelete", encodeNodeName(name))
-			resp, err := client.Do(client.NewRequest(), http.MethodPost, path, nil)
+			resp, err := client.DoRaw(client.NewRequest(), http.MethodPost, path, nil)
 			if err != nil {
 				return err
 			}
@@ -182,7 +182,7 @@ func toggleNode(cmd *cobra.Command, f *cmdutil.Factory, name string, offline boo
 	params.Set("offline", desired)
 
 	endpoint := fmt.Sprintf("/computer/%s/toggleOffline?%s", encodedName, params.Encode())
-	resp, err := client.Do(client.NewRequest(), http.MethodPost, endpoint, nil)
+	resp, err := client.DoRaw(client.NewRequest(), http.MethodPost, endpoint, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/plugin/plugin.go
+++ b/pkg/cmd/plugin/plugin.go
@@ -133,7 +133,7 @@ func newPluginInstallCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			req := client.NewRequest().SetBody(payload).SetHeader("Content-Type", "text/xml")
-			resp, err := client.Do(req, http.MethodPost, "/pluginManager/installNecessaryPlugins", nil)
+			resp, err := client.DoRaw(req, http.MethodPost, "/pluginManager/installNecessaryPlugins", nil)
 			if err != nil {
 				return err
 			}
@@ -209,7 +209,7 @@ func newPluginToggleCmd(f *cmdutil.Factory, enable bool) *cobra.Command {
 			}
 
 			path := fmt.Sprintf("/pluginManager/plugin/%s/%s", url.PathEscape(name), verb)
-			resp, err := client.Do(client.NewRequest(), http.MethodPost, path, nil)
+			resp, err := client.DoRaw(client.NewRequest(), http.MethodPost, path, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/queue/queue.go
+++ b/pkg/cmd/queue/queue.go
@@ -85,7 +85,7 @@ func newQueueCancelCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			req := client.NewRequest().SetQueryParam("id", args[0])
-			resp, err := client.Do(req, http.MethodPost, "/queue/cancelItem", nil)
+			resp, err := client.DoRaw(req, http.MethodPost, "/queue/cancelItem", nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/run/params.go
+++ b/pkg/cmd/run/params.go
@@ -126,7 +126,7 @@ func fetchParamsFromConfig(ctx context.Context, client *jenkins.Client, jobPath 
 	req := client.NewRequest().SetHeader("Accept", "application/xml")
 	req.SetContext(ctx)
 
-	resp, err := client.Do(req, http.MethodGet, path, nil)
+	resp, err := client.DoRaw(req, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -1199,9 +1199,7 @@ func newRunViewCmd(f *cmdutil.Factory) *cobra.Command {
 				return fmt.Errorf("invalid build number: %w", err)
 			}
 
-			path := fmt.Sprintf("/%s/%d/api/json", jenkins.EncodeJobPath(args[0]), num)
-			var detail runDetail
-			_, err = client.Do(client.NewRequest(), http.MethodGet, path, &detail)
+			detail, err := fetchRunDetail(client, args[0], num)
 			if err != nil {
 				return err
 			}
@@ -1221,7 +1219,7 @@ func newRunViewCmd(f *cmdutil.Factory) *cobra.Command {
 				}
 
 				// Refresh detail after wait completes
-				_, err = client.Do(client.NewRequest(), http.MethodGet, path, &detail)
+				detail, err = fetchRunDetail(client, args[0], num)
 				if err != nil {
 					return err
 				}
@@ -1232,7 +1230,7 @@ func newRunViewCmd(f *cmdutil.Factory) *cobra.Command {
 				jklog.L().Debug().Err(err).Msg("fetch test report failed")
 			}
 
-			output := buildRunDetailOutput(args[0], detail, testReport)
+			output := buildRunDetailOutput(args[0], *detail, testReport)
 
 			// Handle --result flag
 			if resultOnly {
@@ -1344,7 +1342,7 @@ func newRunCancelCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			path := fmt.Sprintf("/%s/%d/%s", jenkins.EncodeJobPath(args[0]), num, action)
-			resp, err := client.Do(client.NewRequest(), http.MethodPost, path, nil)
+			resp, err := client.DoRaw(client.NewRequest(), http.MethodPost, path, nil)
 			if err != nil {
 				return err
 			}
@@ -1516,7 +1514,7 @@ func validateJobIsBuildable(client *jenkins.Client, jobPath string) error {
 	// Fetch job metadata to check its type
 	path := fmt.Sprintf("/%s/api/json", jenkins.EncodeJobPath(jobPath))
 	var metadata jobMetadata
-	resp, err := client.Do(
+	resp, err := client.DoRaw(
 		client.NewRequest().SetQueryParam("tree", "jobs[name,_class],_class"),
 		http.MethodGet,
 		path,
@@ -1529,6 +1527,9 @@ func validateJobIsBuildable(client *jenkins.Client, jobPath string) error {
 	// If 404, the job doesn't exist - let triggerBuild handle it
 	if resp.StatusCode() == http.StatusNotFound {
 		return nil
+	}
+	if resp.StatusCode() >= 400 {
+		return fmt.Errorf("check whether %s is buildable: %s", jobPath, resp.Status())
 	}
 
 	// Check if it's a multibranch pipeline
@@ -1570,7 +1571,7 @@ func triggerBuild(client *jenkins.Client, jobPath string, params map[string]stri
 		methodPath = fmt.Sprintf("/%s/buildWithParameters", encoded)
 	}
 
-	resp, err := client.Do(req, http.MethodPost, methodPath, nil)
+	resp, err := client.DoRaw(req, http.MethodPost, methodPath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1644,7 +1645,7 @@ func fetchRunDetail(client *jenkins.Client, jobPath string, buildNumber int64) (
 	path := fmt.Sprintf("/%s/%d/api/json", jenkins.EncodeJobPath(jobPath), buildNumber)
 	_, err := client.Do(client.NewRequest(), http.MethodGet, path, &detail)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("view run %s #%d: %w", jobPath, buildNumber, err)
 	}
 	return &detail, nil
 }
@@ -1893,7 +1894,7 @@ func resolveJobPath(cmd *cobra.Command, client *jenkins.Client, jobPath string, 
 // jobExists checks if a job exists (returns false on 404, error on other failures)
 func jobExists(client *jenkins.Client, jobPath string) (bool, error) {
 	path := fmt.Sprintf("/%s/api/json", jenkins.EncodeJobPath(jobPath))
-	resp, err := client.Do(
+	resp, err := client.DoRaw(
 		client.NewRequest().SetQueryParam("tree", "_class"),
 		http.MethodGet,
 		path,

--- a/pkg/cmd/run/search.go
+++ b/pkg/cmd/run/search.go
@@ -224,7 +224,7 @@ func discoverJobs(ctx context.Context, client *jenkins.Client, folderPath, jobGl
 		}
 
 		var payload jobListPayload
-		resp, err := client.Do(client.NewRequest().SetContext(ctx).SetQueryParam("tree", "jobs[name,_class]"), http.MethodGet, encoded, &payload)
+		resp, err := client.DoRaw(client.NewRequest().SetContext(ctx).SetQueryParam("tree", "jobs[name,_class]"), http.MethodGet, encoded, &payload)
 		if err != nil {
 			return err
 		}
@@ -306,7 +306,7 @@ func walkAndAddAllBranches(ctx context.Context, client *jenkins.Client, multibra
 	tree := "jobs[name,_class]"
 
 	var payload jobListPayload
-	resp, err := client.Do(
+	resp, err := client.DoRaw(
 		client.NewRequest().
 			SetContext(ctx).
 			SetQueryParam("tree", tree),

--- a/pkg/cmd/shared/log_stream.go
+++ b/pkg/cmd/shared/log_stream.go
@@ -40,7 +40,7 @@ func StreamProgressiveLog(ctx context.Context, client *jenkins.Client, jobPath s
 			req.SetContext(ctx)
 		}
 
-		resp, err := client.Do(req, http.MethodGet, path, nil)
+		resp, err := client.DoRaw(req, http.MethodGet, path, nil)
 		if err != nil {
 			if ctx != nil && ctx.Err() != nil {
 				return nil
@@ -52,6 +52,9 @@ func StreamProgressiveLog(ctx context.Context, client *jenkins.Client, jobPath s
 			offset = 0
 			time.Sleep(interval)
 			continue
+		}
+		if resp.StatusCode() >= 400 {
+			return fmt.Errorf("stream log for %s #%d: %s", jobPath, buildNumber, resp.Status())
 		}
 
 		body := resp.RawBody()
@@ -121,7 +124,7 @@ func CollectLogSnapshot(ctx context.Context, client *jenkins.Client, jobPath str
 			req.SetContext(ctx)
 		}
 
-		resp, err := client.Do(req, http.MethodGet, path, nil)
+		resp, err := client.DoRaw(req, http.MethodGet, path, nil)
 		if err != nil {
 			if ctx != nil && ctx.Err() != nil {
 				return truncated, ctx.Err()
@@ -133,6 +136,9 @@ func CollectLogSnapshot(ctx context.Context, client *jenkins.Client, jobPath str
 			offset = 0
 			time.Sleep(150 * time.Millisecond)
 			continue
+		}
+		if resp.StatusCode() >= 400 {
+			return truncated, fmt.Errorf("collect log for %s #%d: %s", jobPath, buildNumber, resp.Status())
 		}
 
 		body := resp.RawBody()

--- a/pkg/cmd/shared/test_report.go
+++ b/pkg/cmd/shared/test_report.go
@@ -42,13 +42,16 @@ func FetchTestReport(client *jenkins.Client, jobPath string, buildNumber int64) 
 	req := client.NewRequest()
 
 	var report TestReport
-	resp, err := client.Do(req, http.MethodGet, path, &report)
+	resp, err := client.DoRaw(req, http.MethodGet, path, &report)
 	if err != nil {
 		return nil, err
 	}
 
 	if resp.StatusCode() == http.StatusNotFound {
 		return nil, nil
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, fmt.Errorf("fetch test report failed: %s", resp.Status())
 	}
 
 	return &report, nil

--- a/skills/jk/SKILL.md
+++ b/skills/jk/SKILL.md
@@ -39,7 +39,7 @@ If the command fails or `jk` is not found, install it using one of these methods
 jk auth login https://jenkins.example.com --username alice --token <API_TOKEN>
 
 # Login to a Jenkins controller that uses Google/OIDC/SSO in the browser
-jk auth login https://jenkins.example.com --username alice@example.com --token <JENKINS_API_TOKEN>
+jk auth login https://jenkins.example.com --username <jenkins-user-id> --token <JENKINS_API_TOKEN>
 
 # Login with custom context name
 jk auth login https://jenkins.example.com --name prod --username alice --token <TOKEN>
@@ -58,7 +58,7 @@ jk auth logout prod         # Logout from specific context
 
 Options for `auth login`:
 - `--name` — Context name (defaults to hostname)
-- `--username` — Jenkins user ID (Google/SSO users: usually your email)
+- `--username` — Jenkins user ID (SSO users: use browser `/whoAmI/api/json` if unsure)
 - `--token` — Jenkins API token
 - `--insecure` — Skip TLS verification
 - `--proxy` — Proxy URL
@@ -66,7 +66,7 @@ Options for `auth login`:
 - `--set-active` — Set as active context (default: true)
 - `--allow-insecure-store` — Allow encrypted file fallback
 
-For Google OAuth, OpenID Connect, Okta, Azure AD, or other browser SSO security realms, first sign in to Jenkins in the browser and create a Jenkins API token from `/me/configure`. Use that Jenkins API token with `--token`; do not use a Google/OIDC access token.
+For Google OAuth, OpenID Connect, Okta, Azure AD, or other browser SSO security realms, first sign in to Jenkins in the browser and create a Jenkins API token from `/me/configure`. Use that Jenkins API token with `--token`; do not use a Google/OIDC access token. If the username/email is rejected, open `<jenkins-url>/whoAmI/api/json` in the signed-in browser and use the returned `name` value as `--username`.
 
 ## Contexts
 

--- a/skills/jk/references/commands.md
+++ b/skills/jk/references/commands.md
@@ -11,7 +11,7 @@ Complete command reference for `jk`. Run `jk <command> --help` for details.
 jk auth login https://jenkins.example.com --username alice --token <API_TOKEN>
 
 # Login to a Jenkins controller that uses Google/OIDC/SSO in the browser
-jk auth login https://jenkins.example.com --username alice@example.com --token <JENKINS_API_TOKEN>
+jk auth login https://jenkins.example.com --username <jenkins-user-id> --token <JENKINS_API_TOKEN>
 
 # With context name
 jk auth login https://jenkins.example.com --name prod --username alice --token <TOKEN>
@@ -29,7 +29,7 @@ jk auth login https://jenkins.example.com --username alice --token <TOKEN> --all
 
 Options:
 - `--name` — Context name (defaults to hostname)
-- `--username` — Jenkins user ID (Google/SSO users: usually your email)
+- `--username` — Jenkins user ID (SSO users: use browser `/whoAmI/api/json` if unsure)
 - `--token` — Jenkins API token
 - `--insecure` — Skip TLS verification
 - `--proxy` — Proxy URL
@@ -37,7 +37,7 @@ Options:
 - `--set-active` — Set as active context (default: true)
 - `--allow-insecure-store` — Allow encrypted file fallback
 
-For Google OAuth, OpenID Connect, Okta, Azure AD, or other browser SSO security realms, first sign in to Jenkins in the browser and create a Jenkins API token from `/me/configure`. Use that Jenkins API token with `--token`; do not use a Google/OIDC access token.
+For Google OAuth, OpenID Connect, Okta, Azure AD, or other browser SSO security realms, first sign in to Jenkins in the browser and create a Jenkins API token from `/me/configure`. Use that Jenkins API token with `--token`; do not use a Google/OIDC access token. If the username/email is rejected, open `<jenkins-url>/whoAmI/api/json` in the signed-in browser and use the returned `name` value as `--username`.
 
 ### Status and Logout
 

--- a/skills/jk/rules/auth.md
+++ b/skills/jk/rules/auth.md
@@ -38,7 +38,7 @@ jk auth login <url> [flags]
 | `--proxy` |  | Proxy URL for this context |
 | `--set-active` |  | Set the context as active after login |
 | `--token` |  | Jenkins API token |
-| `--username` |  | Jenkins user ID (Google/SSO users: usually your email) |
+| `--username` |  | Jenkins user ID (SSO users: use browser /whoAmI/api/json if unsure) |
 
 ### Inherited Flags
 

--- a/skills/jk/rules/auth.md
+++ b/skills/jk/rules/auth.md
@@ -34,6 +34,7 @@ jk auth login <url> [flags]
 | `--ca-file` |  | Custom CA bundle for TLS verification |
 | `--insecure` |  | Skip TLS certificate verification |
 | `--name` |  | Context name (defaults to Jenkins hostname) |
+| `--no-verify` |  | Skip credential verification against the controller |
 | `--proxy` |  | Proxy URL for this context |
 | `--set-active` |  | Set the context as active after login |
 | `--token` |  | Jenkins API token |

--- a/test/e2e/auth_sso_test.go
+++ b/test/e2e/auth_sso_test.go
@@ -1,0 +1,279 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestGoogleLoginRealmAPIToken proves the documented claim for SSO-realm
+// controllers (issue #77): Jenkins core validates API tokens before the
+// security realm, so Basic auth with a real API token keeps working when the
+// realm is the google-login plugin — and password Basic auth stops working.
+func TestGoogleLoginRealmAPIToken(t *testing.T) {
+	h := requireHarness(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	apiToken, err := h.mintAPIToken(ctx, "jk-e2e-sso")
+	if err != nil {
+		t.Fatalf("mint API token: %v", err)
+	}
+
+	// Login + verification under the local realm with a real API token.
+	loginArgs := []string{
+		"auth", "login", h.baseURL,
+		"--username", h.adminUser,
+		"--token", apiToken,
+		"--name", "sso-e2e",
+		"--set-active=false",
+	}
+	if stdout, stderr, err := h.runCLI(ctx, loginArgs...); err != nil {
+		t.Fatalf("login with API token failed: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+
+	// Restore the local realm no matter how the test exits. The restore script
+	// authenticates with the API token, which stays valid under the google
+	// realm; a follow-up password-authenticated request proves the restore.
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cleanupCancel()
+
+		restore := `import hudson.security.HudsonPrivateSecurityRealm
+jenkins.model.Jenkins.get().setSecurityRealm(new HudsonPrivateSecurityRealm(false))
+println("restored")`
+		if err := h.runScript(cleanupCtx, h.adminUser, apiToken, restore); err != nil {
+			t.Errorf("restore local security realm: %v", err)
+			return
+		}
+		if err := h.checkPasswordAuth(cleanupCtx); err != nil {
+			t.Errorf("password auth not working after realm restore: %v", err)
+		}
+	})
+
+	// Switch to the google-login realm transiently (no save): browser SSO
+	// realm with throwaway OAuth client credentials.
+	switchScript := `import org.jenkinsci.plugins.googlelogin.GoogleOAuth2SecurityRealm
+jenkins.model.Jenkins.get().setSecurityRealm(new GoogleOAuth2SecurityRealm("fake-client-id", "fake-client-secret", "example.com"))
+println("switched")`
+	if err := h.runScript(ctx, h.adminUser, h.adminPassword, switchScript); err != nil {
+		t.Fatalf("switch to google-login realm: %v", err)
+	}
+
+	// GET path: API token must authenticate reads under the google realm.
+	stdout, stderr, err := h.runCLI(ctx, "--context", "sso-e2e", "job", "ls", "--folder", "dogfood")
+	if err != nil {
+		t.Fatalf("job ls under google-login realm failed: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "jk-smoke") {
+		t.Fatalf("expected job list to contain jk-smoke, got: %s", stdout)
+	}
+
+	// POST path: round-trip config.xml (fetch, then post the same payload)
+	// proves crumb fetch + authenticated POST under the google realm.
+	configXML, stderr, err := h.runCLI(ctx, "--context", "sso-e2e", "job", "config", "dogfood/jk-smoke")
+	if err != nil {
+		t.Fatalf("job config under google-login realm failed: %v\nstderr: %s", err, stderr)
+	}
+	configPath := filepath.Join(t.TempDir(), "jk-smoke.config.xml")
+	if err := os.WriteFile(configPath, []byte(configXML), 0o600); err != nil {
+		t.Fatalf("write config.xml: %v", err)
+	}
+	if stdout, stderr, err := h.runCLI(ctx, "--context", "sso-e2e", "job", "configure", "dogfood/jk-smoke", "--file", configPath); err != nil {
+		t.Fatalf("job configure under google-login realm failed: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+
+	// Negative: password Basic auth is rejected by the google realm, so login
+	// verification must fail with SSO guidance and roll the context back.
+	negativeArgs := []string{
+		"auth", "login", h.baseURL,
+		"--username", h.adminUser,
+		"--token", h.adminPassword,
+		"--name", "sso-neg",
+		"--set-active=false",
+	}
+	stdout, stderr, err = h.runCLI(ctx, negativeArgs...)
+	if err == nil {
+		t.Fatalf("expected password login to fail under google-login realm\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "API token") {
+		t.Fatalf("expected SSO guidance mentioning API token in stderr, got: %s", stderr)
+	}
+	contexts, stderr, err := h.runCLI(ctx, "context", "ls")
+	if err != nil {
+		t.Fatalf("context ls failed: %v\nstderr: %s", err, stderr)
+	}
+	if strings.Contains(contexts, "sso-neg") {
+		t.Fatalf("context sso-neg should have been rolled back, got: %s", contexts)
+	}
+}
+
+// mintAPIToken creates a real Jenkins API token for the admin user through
+// the token-generation endpoint (crumb + session cookie + password auth).
+func (h *harness) mintAPIToken(ctx context.Context, tokenName string) (string, error) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return "", err
+	}
+	client := &http.Client{Timeout: 15 * time.Second, Jar: jar}
+
+	crumbField, crumbValue, err := h.fetchCrumb(ctx, client)
+	if err != nil {
+		return "", err
+	}
+
+	endpoint := fmt.Sprintf("%s/me/descriptorByName/jenkins.security.ApiTokenProperty/generateNewToken", h.baseURL)
+	form := url.Values{"newTokenName": {tokenName}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.SetBasicAuth(h.adminUser, h.adminPassword)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set(crumbField, crumbValue)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("generateNewToken: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var parsed struct {
+		Data struct {
+			TokenValue string `json:"tokenValue"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("decode generateNewToken response: %w (%s)", err, string(body))
+	}
+	if parsed.Data.TokenValue == "" {
+		return "", fmt.Errorf("generateNewToken returned empty token: %s", string(body))
+	}
+	return parsed.Data.TokenValue, nil
+}
+
+// runScript executes a Groovy script through the Jenkins script console.
+func (h *harness) runScript(ctx context.Context, user, secret, script string) error {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: 30 * time.Second, Jar: jar}
+
+	crumbField, crumbValue, err := h.fetchCrumbAs(ctx, client, user, secret)
+	if err != nil {
+		return err
+	}
+
+	form := url.Values{"script": {script}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.baseURL+"/scriptText", strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(user, secret)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set(crumbField, crumbValue)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("scriptText: status %d: %s", resp.StatusCode, string(body))
+	}
+	if strings.Contains(string(body), "Exception") {
+		return fmt.Errorf("scriptText returned exception: %s", string(body))
+	}
+	return nil
+}
+
+func (h *harness) fetchCrumb(ctx context.Context, client *http.Client) (string, string, error) {
+	return h.fetchCrumbAs(ctx, client, h.adminUser, h.adminPassword)
+}
+
+func (h *harness) fetchCrumbAs(ctx context.Context, client *http.Client, user, secret string) (string, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.baseURL+"/crumbIssuer/api/json", nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.SetBasicAuth(user, secret)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("crumbIssuer: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var parsed struct {
+		Crumb             string `json:"crumb"`
+		CrumbRequestField string `json:"crumbRequestField"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", "", fmt.Errorf("decode crumb response: %w", err)
+	}
+	if parsed.Crumb == "" || parsed.CrumbRequestField == "" {
+		return "", "", fmt.Errorf("crumb response missing fields: %s", string(body))
+	}
+	return parsed.CrumbRequestField, parsed.Crumb, nil
+}
+
+// checkPasswordAuth confirms password Basic auth works (local realm active).
+func (h *harness) checkPasswordAuth(ctx context.Context) error {
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.baseURL+"/api/json", nil)
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(h.adminUser, h.adminPassword)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("password auth check: status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Part 1 of #77 (google-login scenario). Jenkins core validates API tokens **before** the security realm, so token-based CLI access works under browser-SSO realms like `google-login` — but this was never verified, and failures surfaced as vague errors or HTML parse noise. This PR proves the path end-to-end and makes every failure mode actionable:

- **`jk auth login` now verifies credentials** via `/whoAmI/api/json`. Definite rejections (401/403, anonymous, SSO redirect) fail the login with API-token guidance and **restore the previous context, token, and active selection** — a typo can't clobber a working login. Unreachable controllers save unverified with a warning; `--no-verify` skips the check.
- **SSO-redirect detection on every request**: redirects to sign-in pages (Jenkins `/login`/`/loginError`, `securityRealm/commenceLogin` on any host, IdP authorize endpoints such as `accounts.google.com`) abort with a typed, sanitized error explaining the Jenkins API token workflow. Other redirects (e.g. artifact downloads to object storage) still follow, capped at 10 hops.
- **E2E proof**: the e2e controller installs the `google-login` plugin; `TestGoogleLoginRealmAPIToken` transiently switches the realm to `GoogleOAuth2SecurityRealm`, exercises GET + crumb/POST with a real API token, asserts password Basic auth fails with guidance and rolls back, then restores the local realm.
- Docs (README, docs/spec.md), CHANGELOG, regenerated skill rules for `--no-verify`.

Out of scope (part 2, pending reporter diagnostics on #77): bearer auth mode, token-command helpers, and `Proxy-Authorization` for IAP front doors. Service accounts cannot work on plain google-login (browser-only realm) — documented explicitly.

## Test plan

- [x] `make build`, `make lint` (0 issues), gofmt clean
- [x] `make test` — 6 new redirect-policy unit tests, 8 new auth-login verification/rollback tests
- [x] `make e2e` full suite (Colima) — includes the new `TestGoogleLoginRealmAPIToken`
- [x] Isolated `go test -v -run TestGoogleLoginRealmAPIToken ./test/e2e/` → PASS (2.71s)
- [x] Peer review: plan and diff reviewed and approved by codex (independent full-suite e2e pass included)

Relates to #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)