### PR TITLE
chore(release): v0.0.35

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jk",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "GitHub CLI-style interface for Jenkins controllers - create multibranch jobs, inspect config.xml, and manage runs, logs, artifacts, credentials, nodes, and queues",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jk",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "GitHub CLI-style interface for Jenkins controllers - create multibranch jobs, inspect config.xml, and manage runs, logs, artifacts, credentials, nodes, and queues",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.0.35] - 2026-06-19
 ### Added
 - Added a Codex plugin composer icon for marketplace display (#85).
 - `jk auth login` now verifies credentials against the controller (`/whoAmI/api/json`): definite rejections fail the login with SSO-aware guidance and restore the previous context, token, and active selection; unreachable controllers save unverified with a warning; `--no-verify` skips the check (#77).
@@ -19,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Documented noninteractive encrypted file-store unlocks via `JK_KEYRING_PASSPHRASE`, `KEYRING_FILE_PASSWORD`, or `KEYRING_PASSWORD`, and clarified that `KEYRING_BACKEND` remains the explicit backend override.
+
 
 ## [0.0.34] - 2026-05-13
 ### Changed

--- a/skills/jk/SKILL.md
+++ b/skills/jk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jk
-version: 0.0.34
+version: 0.0.35
 description: Jenkins CLI for controllers. Use when users need to manage jobs, pipelines, config.xml, runs, logs, artifacts, credentials, nodes, or queues in Jenkins. Triggers include "jenkins", "jk", "pipeline", "build", "job create", "job config", "config.xml", "run logs", "jenkins credentials", "jenkins node".
 metadata:
   short-description: Jenkins CLI for jobs, config, pipelines, runs


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.0.35`
- aligns skill/plugin metadata to `0.0.35`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.0.35`, publishes the release, and publishes skills