### PR TITLE
fix: resolve --context/JK_CONTEXT overrides in auth status and logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `jk auth status` and `jk auth logout` now honor context selection in positional argument, `--context`/`-c`, `JK_CONTEXT`, then active-context order. This prevents `jk -c ctx-b auth logout` from deleting the active context's configuration and credentials, and status labels a selected non-active context accurately (#127).
+
 ## [0.0.35] - 2026-06-19
 ### Added
 - Added a Codex plugin composer icon for marketplace display (#85).

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -14,6 +14,7 @@ import (
 	"github.com/avivsinai/jenkins-cli/internal/jenkins"
 	"github.com/avivsinai/jenkins-cli/internal/secret"
 	"github.com/avivsinai/jenkins-cli/internal/terminal"
+	"github.com/avivsinai/jenkins-cli/pkg/cmd/shared"
 	"github.com/avivsinai/jenkins-cli/pkg/cmdutil"
 )
 
@@ -268,8 +269,6 @@ func deriveContextName(u *url.URL) string {
 }
 
 func newAuthLogoutCmd(f *cmdutil.Factory) *cobra.Command {
-	var contextName string
-
 	cmd := &cobra.Command{
 		Use:   "logout [context]",
 		Short: "Remove credentials for a context",
@@ -280,16 +279,12 @@ func newAuthLogoutCmd(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 
-			if len(args) == 1 {
-				contextName = args[0]
+			contextName, err := resolveAuthContextName(cmd, cfg, args)
+			if err != nil {
+				return err
 			}
-
 			if contextName == "" {
-				name := cfg.Active
-				if name == "" {
-					return errors.New("no context specified and no active context")
-				}
-				contextName = name
+				return errors.New("no context specified and no active context")
 			}
 
 			ctxDef, err := cfg.Context(contextName)
@@ -324,34 +319,52 @@ func newAuthLogoutCmd(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&contextName, "context", "", "Context name to remove (defaults to active)")
 	return cmd
 }
 
 func newAuthStatusCmd(f *cmdutil.Factory) *cobra.Command {
 	return &cobra.Command{
-		Use:   "status",
+		Use:   "status [context]",
 		Short: "Display authentication status",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := f.ResolveConfig()
 			if err != nil {
 				return err
 			}
 
-			ctx, name, err := cfg.ActiveContext()
-			if err != nil && !errors.Is(err, config.ErrContextNotFound) {
+			name, err := resolveAuthContextName(cmd, cfg, args)
+			if err != nil {
 				return err
 			}
-
-			if ctx == nil {
+			if name == "" {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No active context")
 				return nil
 			}
 
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Active context: %s\n", name)
+			ctx, err := cfg.Context(name)
+			if err != nil {
+				if errors.Is(err, config.ErrContextNotFound) {
+					return fmt.Errorf("context %q not found", name)
+				}
+				return err
+			}
+
+			label := "Context"
+			if name == cfg.Active {
+				label = "Active context"
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", label, name)
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "URL: %s\n", ctx.URL)
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Username: %s\n", ctx.Username)
 			return nil
 		},
 	}
+}
+
+func resolveAuthContextName(cmd *cobra.Command, cfg *config.Config, args []string) (string, error) {
+	if len(args) == 1 {
+		return args[0], nil
+	}
+	return shared.ResolveContextName(cmd, cfg)
 }

--- a/pkg/cmd/auth/auth_test.go
+++ b/pkg/cmd/auth/auth_test.go
@@ -65,6 +65,176 @@ func openTestStore(t *testing.T) *secret.Store {
 	return store
 }
 
+func executeAuthCommand(t *testing.T, cfg *config.Config, args ...string) (string, error) {
+	t.Helper()
+
+	f := &cmdutil.Factory{
+		Config: func() (*config.Config, error) {
+			return cfg, nil
+		},
+	}
+	root := &cobra.Command{Use: "jk", SilenceUsage: true}
+	root.PersistentFlags().StringP("context", "c", "", "Active Jenkins context")
+	root.AddCommand(NewCmdAuth(f))
+
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs(args)
+	err := root.Execute()
+	return out.String(), err
+}
+
+func authContextConfig(t *testing.T) *config.Config {
+	t.Helper()
+
+	cfg := &config.Config{}
+	cfg.SetContext("ctx-a", &config.Context{
+		URL:                "https://a.example.com",
+		Username:           "alice",
+		AllowInsecureStore: true,
+	})
+	cfg.SetContext("ctx-b", &config.Context{
+		URL:                "https://b.example.com",
+		Username:           "bob",
+		AllowInsecureStore: true,
+	})
+	require.NoError(t, cfg.SetActive("ctx-a"))
+	return cfg
+}
+
+func TestAuthStatusResolvesContext(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		envContext string
+		wantLabel  string
+		wantURL    string
+	}{
+		{
+			name:      "active context by default",
+			args:      []string{"auth", "status"},
+			wantLabel: "Active context: ctx-a",
+			wantURL:   "URL: https://a.example.com",
+		},
+		{
+			name:      "context flag",
+			args:      []string{"auth", "status", "--context", "ctx-b"},
+			wantLabel: "Context: ctx-b",
+			wantURL:   "URL: https://b.example.com",
+		},
+		{
+			name:       "environment context",
+			args:       []string{"auth", "status"},
+			envContext: "ctx-b",
+			wantLabel:  "Context: ctx-b",
+			wantURL:    "URL: https://b.example.com",
+		},
+		{
+			name:      "positional context",
+			args:      []string{"auth", "status", "ctx-b"},
+			wantLabel: "Context: ctx-b",
+			wantURL:   "URL: https://b.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loginTestEnv(t)
+			t.Setenv("JK_CONTEXT", tt.envContext)
+
+			out, err := executeAuthCommand(t, authContextConfig(t), tt.args...)
+			require.NoError(t, err)
+			require.Contains(t, out, tt.wantLabel)
+			require.Contains(t, out, tt.wantURL)
+			if tt.wantLabel == "Context: ctx-b" {
+				require.NotContains(t, out, "Active context:")
+			}
+		})
+	}
+}
+
+func TestAuthStatusRejectsUnknownContext(t *testing.T) {
+	loginTestEnv(t)
+	t.Setenv("JK_CONTEXT", "")
+
+	_, err := executeAuthCommand(t, authContextConfig(t), "auth", "status", "--context", "bogus")
+	require.EqualError(t, err, `context "bogus" not found`)
+}
+
+func TestAuthLogoutResolvesContext(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		envContext  string
+		wantRemoved string
+	}{
+		{
+			name:        "active context by default",
+			args:        []string{"auth", "logout"},
+			wantRemoved: "ctx-a",
+		},
+		{
+			name:        "context flag",
+			args:        []string{"auth", "logout", "--context", "ctx-b"},
+			envContext:  "ctx-a",
+			wantRemoved: "ctx-b",
+		},
+		{
+			name:        "global shorthand before subcommand",
+			args:        []string{"-c", "ctx-b", "auth", "logout"},
+			envContext:  "ctx-a",
+			wantRemoved: "ctx-b",
+		},
+		{
+			name:        "environment context",
+			args:        []string{"auth", "logout"},
+			envContext:  "ctx-b",
+			wantRemoved: "ctx-b",
+		},
+		{
+			name:        "positional context",
+			args:        []string{"-c", "ctx-a", "auth", "logout", "ctx-b"},
+			envContext:  "ctx-a",
+			wantRemoved: "ctx-b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loginTestEnv(t)
+			t.Setenv("JK_CONTEXT", tt.envContext)
+			cfg := authContextConfig(t)
+			store := openTestStore(t)
+			require.NoError(t, store.Set(secret.TokenKey("ctx-a"), "token-a"))
+			require.NoError(t, store.Set(secret.TokenKey("ctx-b"), "token-b"))
+
+			out, err := executeAuthCommand(t, cfg, tt.args...)
+			require.NoError(t, err)
+			require.Contains(t, out, "Logged out of context "+tt.wantRemoved)
+
+			_, err = cfg.Context(tt.wantRemoved)
+			require.ErrorIs(t, err, config.ErrContextNotFound)
+			_, err = store.Get(secret.TokenKey(tt.wantRemoved))
+			require.ErrorIs(t, err, os.ErrNotExist)
+
+			wantKept := "ctx-a"
+			if tt.wantRemoved == "ctx-a" {
+				wantKept = "ctx-b"
+			}
+			_, err = cfg.Context(wantKept)
+			require.NoError(t, err)
+			_, err = store.Get(secret.TokenKey(wantKept))
+			require.NoError(t, err)
+			if tt.wantRemoved == "ctx-a" {
+				require.Empty(t, cfg.Active)
+			} else {
+				require.Equal(t, "ctx-a", cfg.Active)
+			}
+		})
+	}
+}
+
 func TestAuthLoginVerificationSuccess(t *testing.T) {
 	loginTestEnv(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/skills/jk/rules/auth.md
+++ b/skills/jk/rules/auth.md
@@ -13,7 +13,7 @@ jk auth <command> [flags]
 | Subcommand | Description | Key Flags |
 |---|---|---|
 | [login](#jk-auth-login) | Authenticate to Jenkins and persist a context | `--allow-insecure-store`, `--ca-file`, `--insecure`, `--name` |
-| [logout](#jk-auth-logout) | Remove credentials for a context | `--context` |
+| [logout](#jk-auth-logout) | Remove credentials for a context | — |
 | [status](#jk-auth-status) | Display authentication status | — |
 
 ## jk auth login
@@ -62,16 +62,11 @@ Remove credentials for a context
 jk auth logout [context] [flags]
 ```
 
-### Flags
-
-| Flag | Short | Description |
-|---|---|---|
-| `--context` |  | Context name to remove (defaults to active) |
-
 ### Inherited Flags
 
 | Flag | Short | Description |
 |---|---|---|
+| `--context` | `-c` | Active Jenkins context name (or set JK_CONTEXT env var) |
 | `--format` |  | Output format: json, yaml |
 | `--jq` |  | Filter JSON output using jq expression (requires --json or --format=json) |
 | `--json` |  | Output in JSON format when supported |
@@ -86,7 +81,7 @@ Display authentication status
 ### Usage
 
 ```
-jk auth status [flags]
+jk auth status [context] [flags]
 ```
 
 ### Inherited Flags


### PR DESCRIPTION
## Summary

Fixes #127.

- `jk auth status` and `jk auth logout` now resolve their target context through the shared precedence: positional argument > `--context`/`-c` flag > `JK_CONTEXT` env > active context — matching every other command and the documented behavior of `jk context --help`.
- Removes logout's local `--context` flag, which shadowed the global persistent `--context`/`-c` by name. This was the destructive half of the bug: `jk -c ctx-b auth logout` deleted the **active** context's configuration and credentials instead of `ctx-b`'s. `jk auth logout --context <name>` keeps working via the global flag.
- `jk auth status` accepts an optional `[context]` positional (symmetric with `logout`), labels a non-active selection as `Context:` instead of the misleading `Active context:`, and errors on an unknown context instead of silently falling back.
- Regression tests cover the full precedence matrix for both commands, including the destructive `-c` logout path (verifying the sibling context and its token survive) and an unknown-context negative case. All new tests fail on the pre-fix code.
- CHANGELOG entry under Unreleased; `skills/jk/rules/auth.md` regenerated via `make generate-skill`.

## Test plan

- `go test ./pkg/cmd/auth -count=1` — pass
- `JK_E2E_DISABLE=1 make test` — full unit suite pass
- `make build`, `make check-generated-skill`, `gofmt`/`go vet` clean
- New tests verified to fail against pre-fix `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012A1YbQzp2ouobmFAKcm5xe