### PR TITLE
fix: skip file keyring passphrase prompt for empty passphrase stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Skip the encrypted file keyring passphrase prompt when the secrets directory is empty or existing items unlock with an empty passphrase, so `--allow-insecure-store` no longer asks to unlock unencrypted stores.
+
 
 ## [0.0.36] - 2026-08-11
 ### Fixed

--- a/internal/secret/store.go
+++ b/internal/secret/store.go
@@ -288,12 +288,6 @@ func configureFileBackend(cfg *keyring.Config, opts openOptions) error {
 		}
 	}
 
-	if passphrase != "" {
-		cfg.FilePasswordFunc = keyring.FixedStringPrompt(passphrase)
-	} else {
-		cfg.FilePasswordFunc = keyring.TerminalPrompt
-	}
-
 	dir := opts.fileDir
 	if dir == "" {
 		if userDir, err := os.UserConfigDir(); err == nil {
@@ -304,7 +298,47 @@ func configureFileBackend(cfg *keyring.Config, opts openOptions) error {
 	if dir != "" {
 		cfg.FileDir = dir
 	}
+
+	switch {
+	case passphrase != "":
+		cfg.FilePasswordFunc = keyring.FixedStringPrompt(passphrase)
+	case fileSecretsUnlockWithEmptyPassphrase(cfg):
+		// go-keyring always prompts before decrypting. Skip the prompt when the
+		// store is empty or existing items were written with an empty passphrase
+		// (common for --allow-insecure-store), matching ssh-agent behavior for
+		// unencrypted keys.
+		cfg.FilePasswordFunc = keyring.FixedStringPrompt("")
+	default:
+		cfg.FilePasswordFunc = keyring.TerminalPrompt
+	}
+
 	return nil
+}
+
+// fileSecretsUnlockWithEmptyPassphrase reports whether the file keyring in cfg
+// can be used without an interactive passphrase. An empty or missing directory
+// counts as unlockable so first-time writes do not prompt either.
+func fileSecretsUnlockWithEmptyPassphrase(cfg *keyring.Config) bool {
+	probe := *cfg
+	probe.FilePasswordFunc = keyring.FixedStringPrompt("")
+
+	kr, err := keyring.Open(probe)
+	if err != nil {
+		return false
+	}
+
+	keys, err := kr.Keys()
+	if err != nil {
+		return false
+	}
+
+	if len(keys) > 0 {
+		// try to get a single key to see if the passphrase is correct
+		_, err = kr.Get(keys[0])
+		return err == nil
+	}
+
+	return true
 }
 
 func usesFileBackend(backends []keyring.BackendType) bool {

--- a/internal/secret/store_test.go
+++ b/internal/secret/store_test.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -162,6 +163,116 @@ func TestConfigureFileBackendFallsBackToEnv(t *testing.T) {
 
 	if value != envPass {
 		t.Fatalf("FilePasswordFunc returned %q, expected %q", value, envPass)
+	}
+}
+
+func TestConfigureFileBackendSkipsPromptWhenEmptyPassphraseWorks(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("KEYRING_FILE_PASSWORD", "")
+	t.Setenv("KEYRING_PASSWORD", "")
+
+	dir := filepath.Join(t.TempDir(), "secrets")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	seed, err := keyring.Open(keyring.Config{
+		ServiceName:      serviceName,
+		AllowedBackends:  []keyring.BackendType{keyring.FileBackend},
+		FileDir:          dir,
+		FilePasswordFunc: keyring.FixedStringPrompt(""),
+	})
+	if err != nil {
+		t.Fatalf("seed open: %v", err)
+	}
+	if err := seed.Set(keyring.Item{Key: "context/test/token", Data: []byte("token-value")}); err != nil {
+		t.Fatalf("seed set: %v", err)
+	}
+
+	cfg := keyring.Config{}
+	if err := configureFileBackend(&cfg, openOptions{fileDir: dir}); err != nil {
+		t.Fatalf("configureFileBackend: %v", err)
+	}
+
+	value, err := cfg.FilePasswordFunc("should not prompt")
+	if err != nil {
+		t.Fatalf("FilePasswordFunc: %v", err)
+	}
+	if value != "" {
+		t.Fatalf("FilePasswordFunc returned %q, want empty passphrase", value)
+	}
+
+	store, err := Open(WithAllowFileFallback(true), WithFileDir(dir))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	got, err := store.Get("context/test/token")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "token-value" {
+		t.Fatalf("Get = %q, want %q", got, "token-value")
+	}
+}
+
+func TestConfigureFileBackendSkipsPromptForEmptyDir(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("KEYRING_FILE_PASSWORD", "")
+	t.Setenv("KEYRING_PASSWORD", "")
+
+	dir := filepath.Join(t.TempDir(), "secrets")
+	cfg := keyring.Config{}
+	if err := configureFileBackend(&cfg, openOptions{fileDir: dir}); err != nil {
+		t.Fatalf("configureFileBackend: %v", err)
+	}
+
+	value, err := cfg.FilePasswordFunc("should not prompt")
+	if err != nil {
+		t.Fatalf("FilePasswordFunc: %v", err)
+	}
+	if value != "" {
+		t.Fatalf("FilePasswordFunc returned %q, want empty passphrase", value)
+	}
+}
+
+func TestConfigureFileBackendPromptsWhenPassphraseRequired(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("KEYRING_FILE_PASSWORD", "")
+	t.Setenv("KEYRING_PASSWORD", "")
+
+	dir := filepath.Join(t.TempDir(), "secrets")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	seed, err := keyring.Open(keyring.Config{
+		ServiceName:      serviceName,
+		AllowedBackends:  []keyring.BackendType{keyring.FileBackend},
+		FileDir:          dir,
+		FilePasswordFunc: keyring.FixedStringPrompt("secret-pass"),
+	})
+	if err != nil {
+		t.Fatalf("seed open: %v", err)
+	}
+	if err := seed.Set(keyring.Item{Key: "context/test/token", Data: []byte("token-value")}); err != nil {
+		t.Fatalf("seed set: %v", err)
+	}
+
+	if fileSecretsUnlockWithEmptyPassphrase(&keyring.Config{FileDir: dir}) {
+		t.Fatalf("expected passphrase-protected secrets to require a prompt")
+	}
+
+	cfg := keyring.Config{}
+	if err := configureFileBackend(&cfg, openOptions{fileDir: dir}); err != nil {
+		t.Fatalf("configureFileBackend: %v", err)
+	}
+
+	// TerminalPrompt is the function value itself; compare pointers.
+	if reflect.ValueOf(cfg.FilePasswordFunc).Pointer() != reflect.ValueOf(keyring.TerminalPrompt).Pointer() {
+		t.Fatalf("FilePasswordFunc should be TerminalPrompt when secrets require a passphrase")
 	}
 }
 


### PR DESCRIPTION

## Summary

Probe whether secrets unlock with an empty passphrase before prompting, so insecure file stores created without a password no longer ask to unlock on every command.

## Testing

```
go test ./internal/secret
ok      github.com/avivsinai/jenkins-cli/internal/secret        0.294s
```


## Documentation

- [x] Added release note (if appropriate)

## Checklist

- [x] Code follows project style (`gofmt`, etc.)
- [x] Tests added or updated where needed
- [ ] Related issues linked (if applicable)
