### PR TITLE
docs: point README at #129 and correct docs against the shipped CLI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,9 +11,10 @@ cmd/jk/                  Entry point — calls internal/jkcmd.Main()
 internal/
   jkcmd/                 CLI bootstrap, factory wiring
   jenkins/               HTTP client, CSRF crumb handling, path helpers
-  config/                YAML configuration (~/.config/jk/config.yaml)
+  config/                YAML configuration (<UserConfigDir>/jk/config.yaml)
   secret/                OS keyring token storage (fallback: encrypted file)
   build/                 Version info injected via ldflags
+  docgen/                Generator for skills/jk/rules (make generate-skill)
   log/                   Structured logging (zerolog)
   filter/                JQ-style JSON filtering
   fuzzy/                 Fuzzy-match helpers for interactive selection
@@ -54,21 +55,26 @@ main.go
 IOStreams, Config loader, and a lazy JenkinsClient builder.
 
 **Jenkins client** (`internal/jenkins/Client`) — created per-context; handles
-CSRF crumbs, TLS/proxy settings, and capability detection via `/api/json`.
+CSRF crumbs, TLS/proxy settings, and capability detection via `/jk/api/status`
+(in-memory, 60s TTL).
 
-**Multi-context** — contexts stored in `~/.config/jk/config.yaml`; tokens in
-the OS keyring.  Resolution order: `--context` flag → `JK_CONTEXT` env →
-active context in config.
+**Multi-context** — contexts stored in `<UserConfigDir>/jk/config.yaml`
+(`~/.config/jk` on Linux, `~/Library/Application Support/jk` on macOS,
+`%AppData%\jk` on Windows — Go's `os.UserConfigDir()`); tokens in the OS
+keyring.  Resolution order: `--context` flag → `JK_CONTEXT` env → active
+context in config.
 
 **IOStreams** (`pkg/iostreams`) — wraps stdin/stdout/stderr with TTY detection,
 colour support, pager piping, and progress indicators.
 
 ## Testing strategy
 
-| Layer | Count | Runner |
-|-------|-------|--------|
-| Unit tests | ~230 (23 test files) | `go test ./...` with `JK_E2E_DISABLE=1` |
-| End-to-end | ~60 (test/e2e/) | testcontainers-go — spins up a real Jenkins in Docker |
+| Layer | Location | Runner |
+|-------|----------|--------|
+| Unit tests | `*_test.go` next to the code | `JK_E2E_DISABLE=1 make test` |
+| End-to-end | `test/e2e/` | `make e2e` — testcontainers-go starts a real Jenkins (`jenkins/jenkins:lts-jdk17`) in Docker |
 
-CI runs lint → unit → e2e in sequence.  The e2e suite uses git worktrees
-(`.tmp-jk-e2e/`) to isolate each test's Jenkins home directory.
+CI runs lint → unit → e2e in sequence, plus an independent `check-skills` job.
+`TestMain` starts one Jenkins container shared by the whole e2e suite; a
+scratch git repository under `.tmp-jk-e2e/` serves as the fake SCM remote for
+job-config tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Documentation audit against the shipped CLI: README quickstart now streams logs with `jk log --follow` (`jk run view` has no `--follow`), manual skill install points at `skills/jk`, stale version and platform lists updated; `docs/api.md` filter/operator/field catalogs, `run params` `source` values, cancel/rerun acknowledgements and the `help --json` shape corrected, with companion-plugin endpoints marked as planned; the two agent-cookbook recipes that could not work (`--limit 0`, queued-run detection) rewritten; unimplemented command groups in `docs/spec.md` marked *(planned)*; the `jk` skill documents `--no-verify` and the keyring environment variables; stale `docs/CHANGELOG.md` removed.
 
 ## [0.0.36] - 2026-08-11
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ cmd/jk/              → Entry point only; calls internal/jkcmd.Main()
 internal/
   jkcmd/             → CLI initialization and factory wiring
   jenkins/           → HTTP client (go-resty), CSRF crumb handling, capability detection
-  config/            → YAML configuration (~/.config/jk/config.yaml)
+  config/            → YAML configuration (<UserConfigDir>/jk/config.yaml)
   secret/            → OS keyring token storage (fallback: encrypted file)
   build/             → Version info (injected via ldflags)
   log/               → Structured logging (zerolog)
@@ -71,7 +71,7 @@ main.go → jkcmd.Main() → root.NewCmdRoot(factory) → Cobra Execute()
 
 ### Multi-Context Support
 
-- Contexts stored in `~/.config/jk/config.yaml`
+- Contexts stored in `<UserConfigDir>/jk/config.yaml` (`~/.config/jk` on Linux, `~/Library/Application Support/jk` on macOS, `%AppData%\jk` on Windows)
 - Tokens in OS keyring (macOS Keychain, Linux secretservice, Windows credential manager)
 - Resolution: `--context` flag → `JK_CONTEXT` env → active context in config
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ Releases are automated with the PR-based `./scripts/release.sh X.Y.Z` flow:
 
 1. Update `CHANGELOG.md` under `Unreleased`, then run `./scripts/release.sh X.Y.Z` from `main`.
 2. The script opens a release PR with `chore(release): vX.Y.Z` and aligned skill/plugin metadata.
-3. After the release PR merges, `.github/workflows/release.yml` validates the merged release commit, creates the matching tag, builds binaries for Linux, macOS, and Windows (amd64 + arm64), and publishes the GitHub release with artifacts and checksums.
+3. After the release PR merges, `.github/workflows/release.yml` validates the merged release commit, creates the matching tag, builds binaries for Linux and macOS (amd64 + arm64) and Windows (amd64), and publishes the GitHub release with artifacts and checksums.
 4. Conventional commits (`feat:`, `fix:`, `deps:`) still help keep changelog entries and release summaries consistent.
 
 ## Questions?

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ scoop install jk
 go install github.com/avivsinai/jenkins-cli/cmd/jk@latest
 
 # Or install specific version
-go install github.com/avivsinai/jenkins-cli/cmd/jk@v0.0.29
+go install github.com/avivsinai/jenkins-cli/cmd/jk@v0.0.36
 ```
 
 Binary will be installed to `$GOPATH/bin` (or `$HOME/go/bin` by default).
@@ -103,7 +103,7 @@ npx skild install @avivsinai/jk -t claude -y
 
 ```bash
 git clone https://github.com/avivsinai/jenkins-cli.git
-cp -r jenkins-cli/.claude/skills/jk ~/.claude/skills/
+cp -r jenkins-cli/skills/jk ~/.claude/skills/
 ```
 
 </details>
@@ -124,7 +124,7 @@ jk job scan platform/services/auth-relay
 jk run ls team/app/pipeline --filter result=SUCCESS --since 7d --limit 5 --json --with-meta
 jk run ls team/app/pipeline --include-queued   # include queued builds (shown as qN)
 jk run params team/app/pipeline                    # inspect inferred parameter metadata
-jk run view team/app/pipeline 128 --follow         # stream logs until completion
+jk log team/app/pipeline 128 --follow              # stream logs until completion
 jk artifact download team/app/pipeline 128 -p "**/*.xml" -o out/
 ```
 
@@ -147,7 +147,7 @@ This works because Jenkins validates API tokens before consulting the security r
 - If the request is redirected to a sign-in page (Jenkins form login, `securityRealm/commenceLogin`, or an external identity provider), `jk` reports that the request never authenticated instead of failing on an HTML response. The same detection applies to every `jk` command, so an expired token against an SSO-fronted controller produces an actionable error.
 - If the controller cannot be reached, the credentials are saved unverified with a warning. Use `--no-verify` to skip the check entirely (for example when bootstrapping configuration before the controller is up).
 
-Service accounts cannot authenticate through a browser-based SSO realm like `google-login` — they never become Jenkins users, so they cannot hold API tokens. That setup requires a bearer-validating front door (Google IAP, a JWT filter, or similar) in front of Jenkins; support for bearer/front-door authentication is tracked in [issue #77](https://github.com/avivsinai/jenkins-cli/issues/77).
+Service accounts cannot authenticate through a browser-based SSO realm like `google-login` — they never become Jenkins users, so they cannot hold API tokens. That setup requires a bearer-validating front door (Google IAP, a JWT filter, or similar) in front of Jenkins; support for bearer/front-door authentication is tracked in [issue #129](https://github.com/avivsinai/jenkins-cli/issues/129).
 
 ### Secret Storage
 
@@ -155,7 +155,7 @@ By default, `jk` stores API tokens in the OS keychain. `--allow-insecure-store` 
 
 For noninteractive file-backend use, set `JK_KEYRING_PASSPHRASE` before running `jk`; compatible fallback variables are `KEYRING_FILE_PASSWORD` and `KEYRING_PASSWORD`.
 
-Structured `jk search` output already includes lightweight search metadata; `--with-meta` is only needed for `jk run ls`.
+Structured `jk search` output already includes lightweight search metadata; `--with-meta` is only needed for `jk run ls` (`jk search` accepts it as a no-op for flag parity).
 
 Add `--json`, `--yaml`, or `--format json|yaml` to supported commands for machine-readable output. Use `--jq` or `--template` to select or reshape JSON results.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-
-## [0.1.0-dev] - 2024-10-10
-- Bootstrap Go module, Cobra root command, and project scaffolding.
-- Implement auth/context management backed by OS keyring.
-- Add Jenkins REST client with crumb handling and capability detection.
-- Deliver Phase 1 MVP commands (`job`, `run`, `log`, `artifact`, `queue`, `test`) with `jk run start --follow` streaming logs and returning result-based exit codes.
-- Introduce initial unit tests and Makefile targets (`build`, `test`, `tidy`, `fmt`).

--- a/docs/agent-cookbook.md
+++ b/docs/agent-cookbook.md
@@ -144,8 +144,10 @@ slow = json.loads(subprocess.run([
 
 **CLI:**
 ```bash
-jk run ls team/api/deploy --with-meta --json --limit 0
+jk run ls team/api/deploy --with-meta --json --limit 1
 ```
+
+`--limit 0` is not "no items": values ≤ 0 fall back to the default of 20, so keep the limit small when only `metadata` is needed.
 
 **Python:**
 ```python
@@ -154,7 +156,7 @@ import subprocess
 
 meta = json.loads(subprocess.run([
     "jk", "run", "ls", "team/api/deploy",
-    "--with-meta", "--json", "--limit", "0"
+    "--with-meta", "--json", "--limit", "1"
 ], check=True, capture_output=True, text=True).stdout)["metadata"]
 ```
 
@@ -164,21 +166,28 @@ meta = json.loads(subprocess.run([
 
 **CLI:**
 ```bash
-jk run search --folder platform --filter queue.id>0 --select queueId --json
+jk run ls platform/deploy --include-queued --json
 ```
+
+Queued items come first with `status: "queued"`, `number: 0`, `id: "<jobPath>/q<queueId>"`, `startTime` set to the time the item entered the queue, and `fields.queueReason`. `jk run search` does not include queued items, and `--filter queue.id>0` also matches started builds whose `queueId` is positive, so it cannot detect stuck queue entries.
 
 **Python:**
 ```python
 import json
 import subprocess
+from datetime import datetime, timedelta, timezone
 
-runs = json.loads(subprocess.run([
-    "jk", "run", "search",
-    "--folder", "platform",
-    "--filter", "queue.id>0",
-    "--select", "queueId",
-    "--json",
+items = json.loads(subprocess.run([
+    "jk", "run", "ls", "platform/deploy",
+    "--include-queued", "--json",
 ], check=True, capture_output=True, text=True).stdout)["items"]
+
+cutoff = datetime.now(timezone.utc) - timedelta(minutes=15)
+stuck = [
+    it for it in items
+    if it["status"] == "queued"
+    and datetime.fromisoformat(it["startTime"].replace("Z", "+00:00")) < cutoff
+]
 ```
 
 ## 8. Export change authors for auditing

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,8 @@
 
 This document is normative for the Jenkins CLI (`jk`) JSON output modes and the companion plugin REST surfaces. Breaking changes to these contracts require a semver-major release of the CLI and/or plugin.
 
+> **Status:** the companion plugin is not shipped yet (`plugin/` is a stub). Every `jk ... --json` shape below is produced today from baseline Jenkins endpoints (`/api/json`, `/logText/progressiveText`, `/credentials/store/...`). The `/jk/api/*` and `/jk/events/*` endpoints are the design contract the plugin will implement; the CLI currently consumes only `/jk/api/status` (capability probe) and `/jk/api/credentials` (`cred ls`, with fallback to core).
+
 ## 1. JSON output conventions
 - All timestamps use RFC3339 (`2006-01-02T15:04:05Z07:00`) in UTC unless otherwise noted.
 - Optional fields are omitted when empty (`omitempty`); arrays default to `[]`.
@@ -10,7 +12,7 @@ This document is normative for the Jenkins CLI (`jk`) JSON output modes and the 
 
 ## 2. Runs
 
-### 2.1 Run detail (`jk run view --json` and `/jk/api/runs/<jobPath>/<build>`)
+### 2.1 Run detail (`jk run view --json`; planned plugin endpoint `/jk/api/runs/<jobPath>/<build>`)
 ```json
 {
   "id": "team/app/main/128",
@@ -60,11 +62,15 @@ This document is normative for the Jenkins CLI (`jk`) JSON output modes and the 
   ],
   "tests": {"total": 420, "failed": 3, "skipped": 5},
   "queue": {"id": 1357, "queuedAt": "2025-08-12T18:23:55Z"},
-  "node": {"displayName": "linux-agent-1", "executor": 0}
+  "node": {"displayName": "linux-agent-1", "executor": 0},
+  "description": "Deploy 1.2.3 to staging",
+  "displayName": "#128"
 }
 ```
 
-### 2.2 Run list (`jk run ls --json` and `/jk/api/runs`)
+`description` and `displayName` are omitted when Jenkins does not set them.
+
+### 2.2 Run list (`jk run ls --json`; planned plugin endpoint `/jk/api/runs`)
 ```json
 {
   "schemaVersion": "1.0",
@@ -103,8 +109,8 @@ This document is normative for the Jenkins CLI (`jk`) JSON output modes and the 
   "nextCursor": "g2wAAAABbQAAAGp...",
   "metadata": {
     "filters": {
-      "available": ["result", "status", "branch", "param.*", "artifact.*"],
-      "operators": ["=", "!=", "~", ">=", "<="]
+      "available": ["result", "status", "branch", "commit", "cause.type", "cause.user", "queue.id", "started", "duration", "param.*", "artifact.*", "cause.*"],
+      "operators": [">=", "<=", "!=", "~=", "~", "=", "^", "$", ">", "<"]
     },
     "parameters": [
       {
@@ -114,7 +120,7 @@ This document is normative for the Jenkins CLI (`jk`) JSON output modes and the 
         "frequency": 1
       }
     ],
-    "fields": ["number", "result", "parameters"],
+    "fields": ["artifacts", "branch", "causes", "commit", "durationms", "estimateddurationms", "number", "parameters", "queueid", "result", "starttime", "status", "url"],
     "selection": ["parameters"],
     "groupBy": "param.CHART_NAME",
     "aggregation": "last"
@@ -162,7 +168,7 @@ This document is normative for the Jenkins CLI (`jk`) JSON output modes and the 
 
 Unlike `jk run ls`, structured search output always includes this lightweight `metadata` block. `--with-meta` is accepted for CLI compatibility, but it is not required.
 
-### 2.4 Progressive log pointer (`/jk/api/runs/<jobPath>/<build>/logs`)
+### 2.4 Progressive log pointer (planned plugin endpoint `/jk/api/runs/<jobPath>/<build>/logs`; the CLI streams via `/logText/progressiveText` today)
 ```json
 {
   "text": "Running on linux-agent-1...\n",
@@ -180,19 +186,19 @@ Unlike `jk run ls`, structured search output always includes this lightweight `m
 }
 ```
 
-When `--follow` is supplied with `--json`/`--yaml`, the CLI suppresses live log output and, after the run finishes, emits the run detail payload described in §2.1 instead of the acknowledgement.
+`jk run rerun` uses `"message": "rerun requested"`. When `--follow` is supplied with `--json`/`--yaml`, the CLI suppresses live log output and, after the run finishes, emits the run detail payload described in §2.1 instead of the acknowledgement.
 
 ### 2.6 Cancel acknowledgement (`jk run cancel --json`)
 ```json
 {
   "jobPath": "team/app/main",
   "build": 128,
-  "action": "term",
+  "action": "stop",
   "status": "requested"
 }
 ```
 
-The CLI exits successfully once the cancellation request is accepted by Jenkins; it does not wait for the build to terminate.
+`action` mirrors `--mode` (`stop` by default, `term`, or `kill`). The CLI exits successfully once the cancellation request is accepted by Jenkins; it does not wait for the build to terminate.
 
 ### 2.7 Run parameter discovery (`jk run params --json`)
 ```json
@@ -217,7 +223,7 @@ The CLI exits successfully once the cancellation request is accepted by Jenkins;
 }
 ```
 
-`source` reflects the discovery path (`config`, `runs`, or `auto`), and `sampleValues`/`frequency` are derived from recent runs. Secret parameters omit defaults and sample values.
+`source` reflects the discovery path actually used (`config` or `runs`; `--source auto`, the default, tries config first and falls back to runs), and `sampleValues`/`frequency` are derived from recent runs. Secret parameters omit defaults and sample values.
 
 ## 3. Logs
 
@@ -263,7 +269,10 @@ When the run is still executing the snapshot may be truncated; the `truncated` f
 }
 ```
 
-### 4.2 Create/update request payload
+### 4.2 Create/update request payload (planned plugin contract)
+
+The sample below is the planned plugin payload. Today `jk cred create-secret` posts a JSON body `{"": "0", "credentials": {"scope": "GLOBAL", "id": ..., "description": ..., "secret": ..., "$class": "org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl"}}` to the Jenkins core endpoint `/credentials/store/system/domain/_/createCredentials` (or `/<folder>/credentials/store/folder/domain/_/createCredentials`).
+
 ```json
 {
   "scope": "folder",
@@ -325,11 +334,17 @@ When the run is still executing the snapshot may be truncated; the `truncated` f
     "12": "Build result: ABORTED",
     "13": "Build result: NOT_BUILT",
     "14": "Build result: RUNNING (in-progress)"
+  },
+  "environmentVariables": {
+    "JK_CONTEXT": "Override the active Jenkins context (same as --context/-c flag)",
+    "JK_QUIET": "Enable quiet mode for supported commands (same as --quiet/-q flag)"
   }
 }
 ```
 
-## 6. Events (SSE)
+## 6. Events (SSE) — planned plugin contract
+
+No `jk` command consumes this stream yet; the CLI only probes `/sse-gateway/stats` to advertise the capability.
 
 - Endpoint: `/jk/events/stream?topics=run,queue,node`
 - Frames are JSON objects encoded as UTF-8 text events.
@@ -357,13 +372,13 @@ When the run is still executing the snapshot may be truncated; the `truncated` f
   "recommendedClient": "1.0.0"
 }
 ```
-- Clients send `X-JK-Client: <semver>` and `X-JK-Features: <csv>` headers. If the CLI version is below `minClient`, it must fall back to baseline Jenkins APIs and surface a warning to the user.
+- Clients send `X-JK-Client: <semver>` and `X-JK-Features: <csv>` headers. The CLI parses `minClient`/`recommendedClient` but does not act on them yet; the planned behaviour is to fall back to baseline Jenkins APIs and warn when the CLI is below `minClient`.
 
 ## 8. Pagination cursors
 
 - Cursors are opaque URL-safe base64 strings produced by the server; clients cannot introspect them.
 - Requests accept `cursor=<value>` and `limit=<n>`. Servers may ignore `limit` in favor of their own defaults but must not return more than requested.
-- When `nextCursor` is omitted or `null`, the collection is exhausted. Clients may pass `--cursor @prev` to reuse the last seen cursor.
+- When `nextCursor` is omitted or `null`, the collection is exhausted. Pass the value back verbatim with `--cursor <value>`.
 
 ## 9. Enumerations
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,5 +1,7 @@
 # Jenkins CLI ("jk") Specification & Technical Plan
 
+> **Status (v0.0.36):** this document is the design blueprint and still describes planned scope. The shipped command surface is what `jk help --json` reports: `auth`, `context`, `search`, `job`, `run`, `log`, `artifact`, `test`, `cred`, `node`, `queue`, `plugin`, `completion`, `version`. Items marked *(planned)* below — the companion plugin (§10), `casc`/`events`/`metrics`/`extension`/`config`/`analytics`, `jk doctor`, `jk whoami`, telemetry, rate limiting — are not implemented yet.
+
 ## 1. Context & Vision
 - Deliver a cross-platform command line experience that makes Jenkins approachable for day-to-day development workflows while remaining safe for production environments.
 - Pair a lightweight Go CLI with Jenkins intrinsic REST APIs and a thin companion plugin that unifies inconsistent surfaces (runs, credentials, job provisioning, events).
@@ -13,12 +15,12 @@
 - Modular architecture that works against stock Jenkins installs while unlocking richer UX when the companion plugin is installed.
 
 ### Confirmed baselines & policies
-- **Supported Jenkins versions:** full support for three maintained LTS lines at any time — baseline `2.361.4`, baseline + ~12 months, and current LTS — validated continuously in CI. Older LTS versions receive best-effort support only.
+- **Supported Jenkins versions:** target the maintained LTS lines; the e2e suite runs against `jenkins/jenkins:lts-jdk17` (current LTS) in CI. Older LTS versions receive best-effort support only.
 - **Authentication:** v1.0 ships with Jenkins API token + Basic auth, which is also the supported scripted-client path for Google/OIDC/SSO security realms. Browser/device OAuth login flows remain tracked for a post-v1.0 iteration.
 - **Air-gapped & FIPS:** provide offline bundles (binaries, checksums, trust store guidance) in v1.0. FIPS-compatible builds are planned for the 1.x roadmap once Go/toolchain support is validated.
 - **Proxy & CA handling:** support `--proxy`, `HTTPS_PROXY`/`NO_PROXY`, and `--ca-file`/`JK_CA_FILE`, with precedence `flag > env > context config`.
-- **Telemetry:** opt-in only (`jk analytics enable|disable` or `JK_ANALYTICS=1`). Payload is limited to command name, duration, exit code, and capability hash; never transmit URLs, tokens, or identifiers.
-- **Distribution:** GitHub Releases (primary), Homebrew tap, and Scoop manifest at GA. Deb/rpm repositories are 1.x backlog.
+- **Telemetry (planned):** opt-in only (`jk analytics enable|disable` or `JK_ANALYTICS=1`); no telemetry code ships today. Payload is limited to command name, duration, exit code, and capability hash; never transmit URLs, tokens, or identifiers.
+- **Distribution:** GitHub Releases (primary), Homebrew tap, Scoop manifest, and `.deb` packages (goreleaser nfpm). RPM packages and apt/yum repositories are backlog.
 - **CLI ↔ plugin version handshake:** CLI sends `X-JK-Client: <semver>` and `X-JK-Features: runs,cred,events,…`. Plugin responds via `/jk/api/status` with `{version, features[], minClient, recommendedClient}` enabling graceful degradation messaging.
 
 ## 3. Non-Goals
@@ -45,7 +47,7 @@ Key workflows the CLI must make trivial:
 - **Authentication & contexts**
   - `jk auth login <url>` stores API tokens and TLS settings, then verifies the credentials via `GET /whoAmI/api/json`: definite rejections (401/403, anonymous, or a redirect to a sign-in page) fail the login and restore the previous context/token/active selection; unreachable controllers save unverified with a warning; `--no-verify` skips the check.
   - Google/OIDC/SSO users authenticate through Jenkins API tokens: sign in through the browser realm, create a token under `/me/configure`, and pass the Jenkins user ID with `--username`. If the user ID is not known, open `/whoAmI/api/json` while signed in through the browser and use the returned `name` value; some SSO realms use an opaque provider ID rather than an email address. Jenkins core validates API tokens before the security realm, so SSO realms (e.g. `google-login`) keep token-based CLI access working — verified by an e2e test that switches the harness controller to the google-login realm.
-  - `jk context ls|use|rm`, `jk whoami`.
+  - `jk context ls|use|rm`; `jk whoami` *(planned)*.
   - Optional `jk auth status` to show crumb/token health.
 - **Jobs & pipeline management**
   - List and view metadata for Jenkins jobs.
@@ -79,7 +81,7 @@ Key workflows the CLI must make trivial:
 - **Events & metrics**
   - Stream events via SSE (`jk events stream --kind run,queue`).
   - Fetch Prometheus metrics snapshots or tail key gauges (queue length, executor usage).
-- **Diagnostics**
+- **Diagnostics** *(planned)*
   - `jk doctor` validates context configuration, reachability, authentication, crumb retrieval, permission checks for core commands, and optional capabilities (SSE, Prometheus) with both human-readable and `--json` output.
 - **Extensions**
   - Install and manage exec-based extensions (`jk extension install <repo>`, `jk extension ls|rm`).
@@ -87,14 +89,14 @@ Key workflows the CLI must make trivial:
 - Support `--json`/`--yaml`/`--format` output and template-friendly fields.
   - Provide shell completions (bash/zsh/fish) and context-aware prompts.
   - Return normative exit codes detailed in §9.6, including specialized mappings for `jk run --follow`.
-  - Telemetry is opt-in via `jk analytics enable|disable` or `JK_ANALYTICS=0|1`; default is disabled.
+  - Telemetry *(planned)* is opt-in via `jk analytics enable|disable` or `JK_ANALYTICS=0|1`; default is disabled.
 
 ## 6. Non-Functional Requirements
 - **Security:** TLS verification by default with explicit opt-out, secure token storage (OS keychain), automatic crumb handling, adherence to Jenkins permissions.
-- **Performance:** `jk log follow` latency < 500 ms refresh; listing commands limited via pagination (`--limit`) and `tree` query parameters to minimize payloads. Outbound request concurrency defaults to 4 in-flight operations (adjustable via `--max-concurrency` or `JK_MAX_CONCURRENCY`) to protect Jenkins controllers.
+- **Performance:** `jk log follow` latency < 500 ms refresh; listing commands limited via pagination (`--limit`) and `tree` query parameters to minimize payloads. Outbound request concurrency limits (`--max-concurrency`, `JK_MAX_CONCURRENCY`) are planned; there is no limiter today.
 - **Reliability:** Commands retry transient network errors; CLI caches crumb until expiry; operations idempotent when possible.
 - **Portability:** Single static binary for macOS (amd64/arm64), Linux (amd64/arm64), Windows (amd64).
-- **Observability:** Optional verbose logging (`JK_DEBUG=1`), structured logs for integration tests, plugin exposes audit logs/metrics.
+- **Observability:** Optional verbose logging (`JK_LOG=debug|trace`), structured logs for integration tests, plugin exposes audit logs/metrics.
 - **Extensibility:** Clear public interfaces for third-party extensions and plugin endpoints; maintain semantic versioning for the CLI and plugin.
 
 ## 7. High-Level Architecture
@@ -143,30 +145,31 @@ Key workflows the CLI must make trivial:
 | Group          | Example commands                                                | Notes |
 |----------------|-----------------------------------------------------------------|-------|
 | `auth`         | `jk auth login`, `jk auth status`, `jk auth logout`             | Stores contexts securely. |
-| `context`      | `jk context ls`, `jk context use`, `jk context rename`          | Config stored under `$XDG_CONFIG_HOME/jk/config.yaml`. |
+| `context`      | `jk context ls`, `jk context use`, `jk context rm`              | Config stored under `os.UserConfigDir()/jk/config.yaml` (`~/.config/jk` on Linux/XDG, `~/Library/Application Support/jk` on macOS, `%AppData%\jk` on Windows). |
 | `search`       | `jk search --job-glob '*ada*'`, `jk search --folder tools`      | Top-level alias for cross-job discovery (`run search`). |
 | `job`          | `jk job ls`, `jk job view`, `jk job create`, `jk job config`, `jk job configure`, `jk job scan` | `create` currently targets Bitbucket-backed Multibranch Pipeline jobs; `config` emits raw XML; `configure` supports `--file`, `--stdin`, or `--script-path`; `scan` is multibranch-only. |
-| `run`          | `jk run start`, `jk run ls`, `jk run search`, `jk run params`, `jk run view`, `jk run cancel`, `jk run rerun`, `jk run restart-from` | Capability flags printed in `jk run view`. |
+| `run`          | `jk run start`, `jk run ls`, `jk run search`, `jk run params`, `jk run view`, `jk run cancel`, `jk run rerun` | `run restart-from` *(planned)*. |
 | `log`          | `jk log`, `jk log --follow`                                     | Snapshot default; `--follow` streams like `gh run view --log`. |
 | `artifact`     | `jk artifact ls`, `jk artifact download`                        | Glob filtering via `--pattern`. |
-| `test`         | `jk test report`, `jk test junit`                               | Format options `--summary`, `--json`. |
+| `test`         | `jk test report`                                                | `--json` output; `jk test junit` *(planned)*. |
 | `cred`         | `jk cred ls`, `jk cred create-secret`, `jk cred rm`  | Additional types added iteratively; falls back to core APIs when plugin absent. |
-| `node`         | `jk node ls`, `jk node cordon`, `jk node uncordon`, `jk node delete` | Cordon optionally sets offline message. |
-| `queue`        | `jk queue ls`, `jk queue cancel`                                | `jk queue ls --watch` uses SSE if available. |
+| `node`         | `jk node ls`, `jk node cordon`, `jk node uncordon`, `jk node rm` | Cordon optionally sets offline message. |
+| `queue`        | `jk queue ls`, `jk queue cancel`                                | `jk queue ls --watch` (SSE) *(planned)*. |
 | `plugin`       | `jk plugin ls`, `jk plugin install`, `jk plugin enable`, `jk plugin disable` | `install` prompts for confirmation unless `--yes`. |
-| `casc`         | `jk casc apply`, `jk casc export`, `jk casc reload`             | Requires admin rights. |
-| `events`       | `jk events stream`, `jk events tail`                             | Fallback to polling with refresh interval when SSE missing. |
-| `metrics`      | `jk metrics dump`, `jk metrics top`                             | `top` keeps refreshing selected gauges. |
-| `extension`    | `jk extension install`, `jk extension ls`, `jk extension rm`    | Exec-based, loads `jk-<name>` on PATH. |
-| `config`       | `jk config set|get|unset`                                       | Manage CLI preferences. |
-| `analytics`    | `jk analytics enable`, `jk analytics disable`, `jk analytics status` | Manage opt-in telemetry state. |
-| Global flags   | `--context`, `--url`, `--token`, `--insecure`, `--json`, `--yaml`, `--format`, `--jq`, `--template`, `--quiet`, `--color=auto|always|never`, `--trace` | CLI resolves context precedence: flag > env > active context. |
+| `casc` *(planned)* | `jk casc apply`, `jk casc export`, `jk casc reload`         | Requires admin rights. |
+| `events` *(planned)* | `jk events stream`, `jk events tail`                       | Fallback to polling with refresh interval when SSE missing. |
+| `metrics` *(planned)* | `jk metrics dump`, `jk metrics top`                       | `top` keeps refreshing selected gauges. |
+| `extension` *(planned)* | `jk extension install`, `jk extension ls`, `jk extension rm` | Exec-based, loads `jk-<name>` on PATH. |
+| `config` *(planned)* | `jk config set|get|unset`                                 | Manage CLI preferences. |
+| `analytics` *(planned)* | `jk analytics enable`, `jk analytics disable`, `jk analytics status` | Manage opt-in telemetry state. |
+| `completion`   | `jk completion bash|zsh|fish|powershell`                        | Cobra-generated shell completions. |
+| Global flags   | `--context/-c`, `--json`, `--yaml`, `--format`, `--jq`, `--template/-t`, `--quiet/-q` | Persistent on the root command. `--url`, `--token`, `--insecure` belong to `auth login`; `--color` and `--trace` are *(planned)*. Context precedence: flag > `JK_CONTEXT` > active context. |
 
 ### 9.2 Configuration & State
-- Config file `config.yaml` holds contexts (name, URL, Jenkins user ID), toggles (color, pager).
+- Config file `config.yaml` holds contexts (`url`, `username`, `insecure`, `proxy`, `ca_file`, `allow_insecure_store`) and `preferences` (`color`, `output_format`, `max_concurrency`).
 - Secrets (API tokens) stored in OS keychain via `go-keyring`; `--allow-insecure-store` or `JK_ALLOW_INSECURE_STORE=1` selects the encrypted file backend instead of native keyrings. `KEYRING_BACKEND` remains an explicit backend override.
 - Proxy configuration precedence is `flag (--proxy) > environment (HTTPS_PROXY/HTTP_PROXY/NO_PROXY) > context config`. CLI also honors custom CA bundles via `--ca-file` and `JK_CA_FILE`.
-- Per-context cache directory stores crumb and small metadata (capabilities, plugin detection caches) with short TTL.
+- Crumb and capability flags are cached in memory for the life of the process (capabilities: 60s TTL); nothing is cached on disk.
 - Context resolution precedence is `--context` > `JK_CONTEXT` > active config (`SetActive`). An empty `JK_CONTEXT` must be treated as unset so automation can clear it without mutating local config.
 
 #### 9.2.1 Code layout (gh parity)
@@ -198,11 +201,11 @@ Key workflows the CLI must make trivial:
 - `--json`/`--yaml`/`--format json|yaml` return stable schemas documented per command; CLI uses struct tags and `omitempty`.
 - `--jq` and `--template` are JSON-only formatters; they are rejected unless JSON output is selected.
 - JSON output is pretty-printed only when stdout is a TTY; piped output is compact.
-- Support pagination flags `--limit`, `--after` for list commands; CLI surfaces server pagination (if plugin adds support) via `Link` headers.
-- Provide `--open` flag for commands that can open Jenkins UI in browser (optional, off by default).
+- Support pagination flags `--limit`, `--cursor` for list commands; CLI surfaces server pagination (if plugin adds support) via `Link` headers.
+- Provide `--open` flag for commands that can open Jenkins UI in browser (optional, off by default) *(planned)*.
 - Autocomplete scripts generated via Cobra's built-in support.
 
-### 9.5 Extension Model
+### 9.5 Extension Model *(planned)*
 - Compatible executables under PATH named `jk-<name>` or installed into `~/.config/jk/extensions/`.
 - `jk extension install <git-url>` clones repo (shallow) and links binary/script, similar to `gh`.
 - CLI offers environment variables to extensions (`JK_CONTEXT`, `JK_JENKINS_URL`, `JK_TOKEN_PATH`).
@@ -303,7 +306,7 @@ Key workflows the CLI must make trivial:
 - During follow mode, emit a short status footer with the final build result to match `gh` UX expectations.
 
 ### 9.10 Capability detection cache
-- On context activation, probe `/jk/api/status`, `/sse-gateway/`, and `/prometheus` once; cache capability flags for 60 seconds or until an operation fails with 404/403/5xx.
+- On first use, probe `/jk/api/status`, `/sse-gateway/stats`, and `/prometheus` once; cache capability flags in memory for 60 seconds.
 - Capability flags include `hasRunsFacade`, `hasCredentialFacade`, `hasEventRouter`, `hasPrometheus`, and `hasSSE`.
 - Commands fall back to core APIs when a capability is absent and emit a single informational warning (suppressed with `--quiet`).
 - `--quiet` (or `JK_QUIET`) also suppresses HTTP client library warnings such as the resty "Using Basic Auth in HTTP mode" message emitted for plain-HTTP Jenkins instances.
@@ -317,13 +320,13 @@ Key workflows the CLI must make trivial:
 ### 9.12 Error messaging standard
 - First line states the human-readable cause (`Error: failed to fetch job 'team/app' (403 Forbidden)`).
 - Follow with concise remediation hint (`hint: check that your token has Job/Read permission`).
-- Mention `--trace` or `JK_DEBUG=1` for verbose logs. Never surface raw HTML responses; log sanitized details under trace mode only.
+- Mention `JK_LOG=debug` (or `--trace`, *planned*) for verbose logs. Never surface raw HTML responses; log sanitized details under trace mode only.
 
-### 9.13 Rate limiting & concurrency controls
+### 9.13 Rate limiting & concurrency controls *(planned)*
 - Default to 4 concurrent outbound requests; configurable via `--max-concurrency` CLI flag, `JK_MAX_CONCURRENCY` env var, or `config.concurrency` per context.
 - Implement token-bucket rate limiting (default 5 requests/second burst 10). Allow overrides via config for high-throughput automation with caution banner.
 
-## 10. Companion Plugin Design
+## 10. Companion Plugin Design *(planned — `plugin/` is a stub; the CLI runs against baseline Jenkins APIs today)*
 
 ### 10.1 Overview
 - Plugin name: `jk-api` (working name).
@@ -392,24 +395,25 @@ Key workflows the CLI must make trivial:
 
 | Command group                                       | Required Jenkins permissions                                           |
 |-----------------------------------------------------|------------------------------------------------------------------------|
-| `auth`, `context`, `config`                         | Client-side only                                                       |
+| `auth`, `context`, `config` *(config planned)*      | Client-side only                                                       |
 | `job ls`, `job view`, `job config`                  | `Overall/Read` + `Job/Read` (folder scoped)                            |
 | `job create`                                        | `Job/Create` + `Job/Configure` (folder scoped)                         |
 | `job configure`                                     | `Overall/Read` + `Job/Read` + `Job/Configure` (folder scoped)         |
 | `job scan`                                          | `Overall/Read` + `Job/Read` + `Job/Build` (folder scoped)             |
 | `run start`                                         | `Job/Build`                                                            |
 | `run cancel`                                        | `Job/Cancel` (or equivalent policy)                                   |
-| `run rerun`, `run restart-from`                     | Plugin-specific (`Rebuild/Build`, `Replay`, `Restart from Stage`)     |
+| `run rerun`                                         | `Job/Build` (re-triggers via core `build`/`buildWithParameters`)      |
+| `run restart-from` *(planned)*                      | Plugin-specific (`Replay`, `Restart from Stage`)                      |
 | `log follow`, `artifact ls/download`, `test report` | `Job/Read`                                                             |
 | `cred ls`                                           | `Credentials/View` (system or folder scoped)                           |
 | `cred create/update/delete`                         | `Credentials/Create`, `Credentials/Update`, `Credentials/Delete`      |
 | `node ls`                                           | `Overall/Read`                                                         |
-| `node cordon/uncordon`, `node delete`               | `Computer/Configure` (delete also `Computer/Delete` if enabled)        |
+| `node cordon/uncordon`, `node rm`                   | `Computer/Configure` (rm also `Computer/Delete` if enabled)            |
 | `queue ls`                                          | `Overall/Read`                                                         |
 | `queue cancel`                                      | `Job/Cancel`                                                           |
 | `plugin ls/install/enable`                          | `Overall/Administer`                                                   |
-| `casc apply/export/reload`                          | `Overall/Administer`                                                   |
-| `events stream`, `metrics`                          | `Overall/Read` (metrics may require `Overall/Administer` per policy)  |
+| `casc apply/export/reload` *(planned)*              | `Overall/Administer`                                                   |
+| `events stream`, `metrics` *(planned)*              | `Overall/Read` (metrics may require `Overall/Administer` per policy)  |
 
 ## 12. Technology Selection & Tooling
 
@@ -455,7 +459,7 @@ Key workflows the CLI must make trivial:
 - Manage dependencies with Renovate or Dependabot.
 - Documentation site generated via MkDocs or Docusaurus (optional) fed by `docs/`.
 
-## 13. Observability & Telemetry
+## 13. Observability & Telemetry *(planned)*
 - CLI:
   - `--trace` flag outputs HTTP request/response summaries (headers sanitized).
   - Optional OpenTelemetry exporter via `JK_OTEL_EXPORTER` for command metrics (duration, exit code) when teams opt in.
@@ -521,7 +525,7 @@ Key workflows the CLI must make trivial:
 - Finalize extension tooling (`jk extension install/ls/rm`).
 - Add CLI telemetry opt-in and improved error messages.
 - Improve artifact filtering, test summaries, queue watch using SSE.
-- Package installers (Homebrew tap, Scoop manifest, Debian/RPM optional).
+- Package installers (Homebrew tap, Scoop manifest, `.deb` via nfpm shipped; RPM optional).
 - Document plugin installation and security practices.
 - Release v1.0.0.
 
@@ -556,7 +560,7 @@ Each phase is gated by acceptance criteria (functional coverage, test suite pass
 
 ## 19. Open Follow-Ups
 - Schedule FIPS-compatible build validation during the 1.x cycle and document cryptography constraints.
-- Gauge demand and prioritize timeline for official deb/rpm repositories after GA.
+- Gauge demand and prioritize timeline for RPM packages and apt/yum repositories after GA (`.deb` artifacts already ship on GitHub Releases).
 - Reassess priority of OIDC/SSO support post-v1.0 based on customer feedback.
 - Monitor usage of `jk analytics` opt-in telemetry and publish governance documentation alongside release notes.
 

--- a/skills/jk/SKILL.md
+++ b/skills/jk/SKILL.md
@@ -65,6 +65,7 @@ Options for `auth login`:
 - `--ca-file` — Custom CA bundle
 - `--set-active` — Set as active context (default: true)
 - `--allow-insecure-store` — Allow encrypted file fallback
+- `--no-verify` — Skip credential verification against the controller
 
 For Google OAuth, OpenID Connect, Okta, Azure AD, or other browser SSO security realms, first sign in to Jenkins in the browser and create a Jenkins API token from `/me/configure`. Use that Jenkins API token with `--token`; do not use a Google/OIDC access token. If the username/email is rejected, open `<jenkins-url>/whoAmI/api/json` in the signed-in browser and use the returned `name` value as `--username`.
 
@@ -393,12 +394,15 @@ jk run start team/app --quiet
 - `--format json|yaml` — Output format
 - `--jq <expr>` — Filter JSON with jq expression
 - `-t, --template <tmpl>` — Format with Go template
-- `-q, --quiet` — Suppress non-essential output
+- `-q, --quiet` — Suppress non-essential output: hides HTTP client warnings for every command. On `run start`/`run rerun` in plain trigger mode (no `--json`/`--yaml`/`--format`, no `--wait`, no `--follow`) it prints only the build number; with `--follow` it drops the status lines while logs still stream
 
 ## Environment Variables
 
 - `JK_CONTEXT` — Override active context
 - `JK_QUIET` — Equivalent to `--quiet` (any value enables)
+- `JK_ALLOW_INSECURE_STORE=1` — Equivalent to `--allow-insecure-store` (encrypted file backend instead of the OS keyring)
+- `JK_KEYRING_PASSPHRASE` — Passphrase for the encrypted file backend, for noninteractive use (`KEYRING_FILE_PASSWORD`/`KEYRING_PASSWORD` also accepted)
+- `KEYRING_BACKEND` — Explicit keyring backend override (advanced)
 
 ## Exit Codes
 

--- a/skills/jk/references/commands.md
+++ b/skills/jk/references/commands.md
@@ -36,6 +36,7 @@ Options:
 - `--ca-file` — Custom CA bundle path
 - `--set-active` — Set as active context (default: true)
 - `--allow-insecure-store` — Allow encrypted file fallback
+- `--no-verify` — Skip credential verification against the controller
 
 For Google OAuth, OpenID Connect, Okta, Azure AD, or other browser SSO security realms, first sign in to Jenkins in the browser and create a Jenkins API token from `/me/configure`. Use that Jenkins API token with `--token`; do not use a Google/OIDC access token. If the username/email is rejected, open `<jenkins-url>/whoAmI/api/json` in the signed-in browser and use the returned `name` value as `--username`.
 
@@ -501,12 +502,15 @@ All commands support:
 - `--format json|yaml` — Output format
 - `--jq <expr>` — Filter JSON with jq expression
 - `-t, --template <tmpl>` — Format with Go template
-- `-q, --quiet` — Suppress non-essential output
+- `-q, --quiet` — Suppress non-essential output: hides HTTP client warnings for every command. On `run start`/`run rerun` in plain trigger mode (no `--json`/`--yaml`/`--format`, no `--wait`, no `--follow`) it prints only the build number; with `--follow` it drops the status lines while logs still stream
 
 ## Environment Variables
 
 - `JK_CONTEXT` — Override active context (empty = use config)
 - `JK_QUIET` — Equivalent to `--quiet` (any value enables)
+- `JK_ALLOW_INSECURE_STORE=1` — Equivalent to `--allow-insecure-store` (encrypted file backend instead of the OS keyring)
+- `JK_KEYRING_PASSPHRASE` — Passphrase for the encrypted file backend, for noninteractive use (`KEYRING_FILE_PASSWORD`/`KEYRING_PASSWORD` also accepted)
+- `KEYRING_BACKEND` — Explicit keyring backend override (advanced)
 
 ## Exit Codes
 


### PR DESCRIPTION
## Summary

Docs-only. Updates the front-door auth link from closed #77 to #129 and fixes what a doc-vs-code audit found (every claim checked against the built binary's `jk help --json` and the source):

- **README**: quickstart used `jk run view --follow` (no such flag) → `jk log --follow`; manual skill install path → `skills/jk`; `go install` example → v0.0.36; `--with-meta` note.
- **ARCHITECTURE / CLAUDE / CONTRIBUTING**: capability probe is `/jk/api/status` (was `/api/json`); config dir is `os.UserConfigDir()/jk` (not `~/.config` on macOS/Windows); test table without stale counts; one e2e Jenkins container per suite; `internal/docgen` listed; Windows builds are amd64 only.
- **docs/api.md**: status banner (companion plugin not shipped); real filter key / operator / select-field catalogs; run detail `description`/`displayName`; `run rerun` message; cancel default `stop`; `run params` `source` values; cred create payload marked planned with the real core request; `help --json` `environmentVariables`; events / `minClient` fallback marked planned; `--cursor @prev` removed.
- **docs/agent-cookbook.md**: recipe 6 `--limit 0` → `--limit 1` (≤0 falls back to 20); recipe 7 rewritten on `run ls --include-queued` (`run search` never includes queued items).
- **docs/spec.md**: status note + *(planned)* markers for `casc`/`events`/`metrics`/`extension`/`config`/`analytics`/`doctor`/`whoami`/telemetry/rate limiting/§10 plugin; `context rm`, `node rm`; real global-flag row; config keys from `internal/config`; in-memory caches; `--cursor`; `.deb` via nfpm; `JK_LOG`; LTS baseline; `completion` row.
- **skills/jk**: `--no-verify`, `--quiet` scope, `JK_ALLOW_INSECURE_STORE` / `JK_KEYRING_PASSPHRASE` / `KEYRING_BACKEND`.
- Removed stale `docs/CHANGELOG.md` (2024 bootstrap, unreferenced); added a CHANGELOG entry.

Refs #129.

## Testing

- `make build`, `make check-skills`, `make check-generated-skill`, `JK_E2E_DISABLE=1 make test`, `git diff --check`, pre-commit hooks on touched files — all green.
- Peer review by execution (codex) on the exact staged snapshot: three rounds, approved.

## Documentation

- [x] Updated README / docs (if user-facing)
- [x] Added release note (if appropriate)

## Checklist

- [x] Code follows project style (`gofmt`, etc.) — docs only
- [x] Tests added or updated where needed — n/a
- [x] Related issues linked (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSRrth2eXoGSYb6DttwaZH
