### PR TITLE
fix: skip file keyring passphrase prompt for empty passphrase stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Documentation audit against the shipped CLI: README quickstart now streams logs with `jk log --follow` (`jk run view` has no `--follow`), manual skill install points at `skills/jk`, stale version and platform lists updated; `docs/api.md` filter/operator/field catalogs, `run params` `source` values, cancel/rerun acknowledgements and the `help --json` shape corrected, with companion-plugin endpoints marked as planned; the two agent-cookbook recipes that could not work (`--limit 0`, queued-run detection) rewritten; unimplemented command groups in `docs/spec.md` marked *(planned)*; the `jk` skill documents `--no-verify` and the keyring environment variables; stale `docs/CHANGELOG.md` removed.
+### Fixed
+- Skip the encrypted file keyring passphrase prompt when the secrets directory is empty or existing items unlock with an empty passphrase, so `--allow-insecure-store` no longer asks to unlock unencrypted stores.
+
 
 ## [0.0.36] - 2026-08-11
 ### Fixed

--- a/internal/secret/store.go
+++ b/internal/secret/store.go
@@ -304,9 +304,9 @@ func configureFileBackend(cfg *keyring.Config, opts openOptions) error {
 		cfg.FilePasswordFunc = keyring.FixedStringPrompt(passphrase)
 	case fileSecretsUnlockWithEmptyPassphrase(cfg):
 		// go-keyring always prompts before decrypting. Skip the prompt when the
-		// store is empty or existing items were written with an empty passphrase
-		// (common for --allow-insecure-store), matching ssh-agent behavior for
-		// unencrypted keys.
+		// existing items were written with an empty passphrase (common for
+		// --allow-insecure-store), matching ssh-agent behavior for unencrypted
+		// keys.
 		cfg.FilePasswordFunc = keyring.FixedStringPrompt("")
 	default:
 		cfg.FilePasswordFunc = keyring.TerminalPrompt
@@ -316,10 +316,14 @@ func configureFileBackend(cfg *keyring.Config, opts openOptions) error {
 }
 
 // fileSecretsUnlockWithEmptyPassphrase reports whether the file keyring in cfg
-// can be used without an interactive passphrase. An empty or missing directory
-// counts as unlockable so first-time writes do not prompt either.
+// can be used without an interactive passphrase. It only returns true after
+// decrypting an existing item with an empty passphrase.
 func fileSecretsUnlockWithEmptyPassphrase(cfg *keyring.Config) bool {
 	probe := *cfg
+	// Probe only the file backend. In particular on macOS, inheriting the
+	// caller's backend list could open the native Keychain instead of the
+	// configured file store.
+	probe.AllowedBackends = []keyring.BackendType{keyring.FileBackend}
 	probe.FilePasswordFunc = keyring.FixedStringPrompt("")
 
 	kr, err := keyring.Open(probe)
@@ -332,13 +336,16 @@ func fileSecretsUnlockWithEmptyPassphrase(cfg *keyring.Config) bool {
 		return false
 	}
 
-	if len(keys) > 0 {
-		// try to get a single key to see if the passphrase is correct
-		_, err = kr.Get(keys[0])
-		return err == nil
+	if len(keys) == 0 {
+		// An empty or cleared store has no evidence that an empty passphrase is
+		// valid. Keep the interactive prompt so a new protected store cannot be
+		// silently downgraded to an empty passphrase.
+		return false
 	}
 
-	return true
+	// Try to get a single key to see if the passphrase is correct.
+	_, err = kr.Get(keys[0])
+	return err == nil
 }
 
 func usesFileBackend(backends []keyring.BackendType) bool {

--- a/internal/secret/store.go
+++ b/internal/secret/store.go
@@ -288,12 +288,6 @@ func configureFileBackend(cfg *keyring.Config, opts openOptions) error {
 		}
 	}
 
-	if passphrase != "" {
-		cfg.FilePasswordFunc = keyring.FixedStringPrompt(passphrase)
-	} else {
-		cfg.FilePasswordFunc = keyring.TerminalPrompt
-	}
-
 	dir := opts.fileDir
 	if dir == "" {
 		if userDir, err := os.UserConfigDir(); err == nil {
@@ -304,7 +298,47 @@ func configureFileBackend(cfg *keyring.Config, opts openOptions) error {
 	if dir != "" {
 		cfg.FileDir = dir
 	}
+
+	switch {
+	case passphrase != "":
+		cfg.FilePasswordFunc = keyring.FixedStringPrompt(passphrase)
+	case fileSecretsUnlockWithEmptyPassphrase(cfg):
+		// go-keyring always prompts before decrypting. Skip the prompt when the
+		// store is empty or existing items were written with an empty passphrase
+		// (common for --allow-insecure-store), matching ssh-agent behavior for
+		// unencrypted keys.
+		cfg.FilePasswordFunc = keyring.FixedStringPrompt("")
+	default:
+		cfg.FilePasswordFunc = keyring.TerminalPrompt
+	}
+
 	return nil
+}
+
+// fileSecretsUnlockWithEmptyPassphrase reports whether the file keyring in cfg
+// can be used without an interactive passphrase. An empty or missing directory
+// counts as unlockable so first-time writes do not prompt either.
+func fileSecretsUnlockWithEmptyPassphrase(cfg *keyring.Config) bool {
+	probe := *cfg
+	probe.FilePasswordFunc = keyring.FixedStringPrompt("")
+
+	kr, err := keyring.Open(probe)
+	if err != nil {
+		return false
+	}
+
+	keys, err := kr.Keys()
+	if err != nil {
+		return false
+	}
+
+	if len(keys) > 0 {
+		// try to get a single key to see if the passphrase is correct
+		_, err = kr.Get(keys[0])
+		return err == nil
+	}
+
+	return true
 }
 
 func usesFileBackend(backends []keyring.BackendType) bool {

--- a/internal/secret/store_test.go
+++ b/internal/secret/store_test.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -162,6 +163,116 @@ func TestConfigureFileBackendFallsBackToEnv(t *testing.T) {
 
 	if value != envPass {
 		t.Fatalf("FilePasswordFunc returned %q, expected %q", value, envPass)
+	}
+}
+
+func TestConfigureFileBackendSkipsPromptWhenEmptyPassphraseWorks(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("KEYRING_FILE_PASSWORD", "")
+	t.Setenv("KEYRING_PASSWORD", "")
+
+	dir := filepath.Join(t.TempDir(), "secrets")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	seed, err := keyring.Open(keyring.Config{
+		ServiceName:      serviceName,
+		AllowedBackends:  []keyring.BackendType{keyring.FileBackend},
+		FileDir:          dir,
+		FilePasswordFunc: keyring.FixedStringPrompt(""),
+	})
+	if err != nil {
+		t.Fatalf("seed open: %v", err)
+	}
+	if err := seed.Set(keyring.Item{Key: "context/test/token", Data: []byte("token-value")}); err != nil {
+		t.Fatalf("seed set: %v", err)
+	}
+
+	cfg := keyring.Config{}
+	if err := configureFileBackend(&cfg, openOptions{fileDir: dir}); err != nil {
+		t.Fatalf("configureFileBackend: %v", err)
+	}
+
+	value, err := cfg.FilePasswordFunc("should not prompt")
+	if err != nil {
+		t.Fatalf("FilePasswordFunc: %v", err)
+	}
+	if value != "" {
+		t.Fatalf("FilePasswordFunc returned %q, want empty passphrase", value)
+	}
+
+	store, err := Open(WithAllowFileFallback(true), WithFileDir(dir))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	got, err := store.Get("context/test/token")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "token-value" {
+		t.Fatalf("Get = %q, want %q", got, "token-value")
+	}
+}
+
+func TestConfigureFileBackendSkipsPromptForEmptyDir(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("KEYRING_FILE_PASSWORD", "")
+	t.Setenv("KEYRING_PASSWORD", "")
+
+	dir := filepath.Join(t.TempDir(), "secrets")
+	cfg := keyring.Config{}
+	if err := configureFileBackend(&cfg, openOptions{fileDir: dir}); err != nil {
+		t.Fatalf("configureFileBackend: %v", err)
+	}
+
+	value, err := cfg.FilePasswordFunc("should not prompt")
+	if err != nil {
+		t.Fatalf("FilePasswordFunc: %v", err)
+	}
+	if value != "" {
+		t.Fatalf("FilePasswordFunc returned %q, want empty passphrase", value)
+	}
+}
+
+func TestConfigureFileBackendPromptsWhenPassphraseRequired(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("KEYRING_FILE_PASSWORD", "")
+	t.Setenv("KEYRING_PASSWORD", "")
+
+	dir := filepath.Join(t.TempDir(), "secrets")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	seed, err := keyring.Open(keyring.Config{
+		ServiceName:      serviceName,
+		AllowedBackends:  []keyring.BackendType{keyring.FileBackend},
+		FileDir:          dir,
+		FilePasswordFunc: keyring.FixedStringPrompt("secret-pass"),
+	})
+	if err != nil {
+		t.Fatalf("seed open: %v", err)
+	}
+	if err := seed.Set(keyring.Item{Key: "context/test/token", Data: []byte("token-value")}); err != nil {
+		t.Fatalf("seed set: %v", err)
+	}
+
+	if fileSecretsUnlockWithEmptyPassphrase(&keyring.Config{FileDir: dir}) {
+		t.Fatalf("expected passphrase-protected secrets to require a prompt")
+	}
+
+	cfg := keyring.Config{}
+	if err := configureFileBackend(&cfg, openOptions{fileDir: dir}); err != nil {
+		t.Fatalf("configureFileBackend: %v", err)
+	}
+
+	// TerminalPrompt is the function value itself; compare pointers.
+	if reflect.ValueOf(cfg.FilePasswordFunc).Pointer() != reflect.ValueOf(keyring.TerminalPrompt).Pointer() {
+		t.Fatalf("FilePasswordFunc should be TerminalPrompt when secrets require a passphrase")
 	}
 }
 

--- a/internal/secret/store_test.go
+++ b/internal/secret/store_test.go
@@ -107,7 +107,10 @@ func TestConfigureFileBackendUsesPassphraseOption(t *testing.T) {
 	t.Helper()
 
 	tmpDir := t.TempDir()
-	cfg := keyring.Config{}
+	cfg := keyring.Config{
+		ServiceName:     serviceName,
+		AllowedBackends: []keyring.BackendType{keyring.FileBackend},
+	}
 	opts := openOptions{
 		passphrase: "secret-pass",
 		fileDir:    filepath.Join(tmpDir, "secrets"),
@@ -143,7 +146,10 @@ func TestConfigureFileBackendFallsBackToEnv(t *testing.T) {
 	t.Setenv("KEYRING_FILE_PASSWORD", envPass)
 	t.Setenv("KEYRING_PASSWORD", "")
 
-	cfg := keyring.Config{}
+	cfg := keyring.Config{
+		ServiceName:     serviceName,
+		AllowedBackends: []keyring.BackendType{keyring.FileBackend},
+	}
 	opts := openOptions{
 		fileDir: filepath.Join(tmpDir, "secrets"),
 	}
@@ -190,7 +196,10 @@ func TestConfigureFileBackendSkipsPromptWhenEmptyPassphraseWorks(t *testing.T) {
 		t.Fatalf("seed set: %v", err)
 	}
 
-	cfg := keyring.Config{}
+	cfg := keyring.Config{
+		ServiceName:     serviceName,
+		AllowedBackends: []keyring.BackendType{keyring.FileBackend},
+	}
 	if err := configureFileBackend(&cfg, openOptions{fileDir: dir}); err != nil {
 		t.Fatalf("configureFileBackend: %v", err)
 	}
@@ -216,24 +225,28 @@ func TestConfigureFileBackendSkipsPromptWhenEmptyPassphraseWorks(t *testing.T) {
 	}
 }
 
-func TestConfigureFileBackendSkipsPromptForEmptyDir(t *testing.T) {
+func TestConfigureFileBackendPromptsForEmptyDir(t *testing.T) {
 	t.Helper()
 
 	t.Setenv("KEYRING_FILE_PASSWORD", "")
 	t.Setenv("KEYRING_PASSWORD", "")
 
 	dir := filepath.Join(t.TempDir(), "secrets")
-	cfg := keyring.Config{}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfg := keyring.Config{
+		ServiceName:     serviceName,
+		AllowedBackends: []keyring.BackendType{keyring.FileBackend},
+	}
 	if err := configureFileBackend(&cfg, openOptions{fileDir: dir}); err != nil {
 		t.Fatalf("configureFileBackend: %v", err)
 	}
 
-	value, err := cfg.FilePasswordFunc("should not prompt")
-	if err != nil {
-		t.Fatalf("FilePasswordFunc: %v", err)
-	}
-	if value != "" {
-		t.Fatalf("FilePasswordFunc returned %q, want empty passphrase", value)
+	// TerminalPrompt is the function value itself; compare pointers instead of
+	// invoking it, which would block the test on stdin.
+	if reflect.ValueOf(cfg.FilePasswordFunc).Pointer() != reflect.ValueOf(keyring.TerminalPrompt).Pointer() {
+		t.Fatalf("FilePasswordFunc should be TerminalPrompt for an empty store")
 	}
 }
 
@@ -261,11 +274,18 @@ func TestConfigureFileBackendPromptsWhenPassphraseRequired(t *testing.T) {
 		t.Fatalf("seed set: %v", err)
 	}
 
-	if fileSecretsUnlockWithEmptyPassphrase(&keyring.Config{FileDir: dir}) {
+	if fileSecretsUnlockWithEmptyPassphrase(&keyring.Config{
+		ServiceName:     serviceName,
+		AllowedBackends: []keyring.BackendType{keyring.FileBackend},
+		FileDir:         dir,
+	}) {
 		t.Fatalf("expected passphrase-protected secrets to require a prompt")
 	}
 
-	cfg := keyring.Config{}
+	cfg := keyring.Config{
+		ServiceName:     serviceName,
+		AllowedBackends: []keyring.BackendType{keyring.FileBackend},
+	}
 	if err := configureFileBackend(&cfg, openOptions{fileDir: dir}); err != nil {
 		t.Fatalf("configureFileBackend: %v", err)
 	}
@@ -273,6 +293,84 @@ func TestConfigureFileBackendPromptsWhenPassphraseRequired(t *testing.T) {
 	// TerminalPrompt is the function value itself; compare pointers.
 	if reflect.ValueOf(cfg.FilePasswordFunc).Pointer() != reflect.ValueOf(keyring.TerminalPrompt).Pointer() {
 		t.Fatalf("FilePasswordFunc should be TerminalPrompt when secrets require a passphrase")
+	}
+}
+
+func TestConfigureFileBackendPromptsAfterClearedProtectedStore(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("KEYRING_FILE_PASSWORD", "")
+	t.Setenv("KEYRING_PASSWORD", "")
+
+	dir := filepath.Join(t.TempDir(), "secrets")
+	const passphrase = "secret-pass"
+	key := TokenKey("test")
+
+	protected, err := Open(
+		WithAllowFileFallback(true),
+		WithPassphrase(passphrase),
+		WithFileDir(dir),
+	)
+	if err != nil {
+		t.Fatalf("open protected store: %v", err)
+	}
+	if err := protected.Set(key, "token-value"); err != nil {
+		t.Fatalf("seed set: %v", err)
+	}
+	if err := protected.Delete(key); err != nil {
+		t.Fatalf("delete last item: %v", err)
+	}
+
+	probeCfg := keyring.Config{
+		ServiceName:     serviceName,
+		AllowedBackends: []keyring.BackendType{keyring.FileBackend},
+		FileDir:         dir,
+	}
+	if fileSecretsUnlockWithEmptyPassphrase(&probeCfg) {
+		t.Fatalf("cleared protected store must not be treated as empty-passphrase unlockable")
+	}
+
+	cfg := keyring.Config{
+		ServiceName:     serviceName,
+		AllowedBackends: []keyring.BackendType{keyring.FileBackend},
+	}
+	if err := configureFileBackend(&cfg, openOptions{fileDir: dir}); err != nil {
+		t.Fatalf("configureFileBackend: %v", err)
+	}
+	if reflect.ValueOf(cfg.FilePasswordFunc).Pointer() != reflect.ValueOf(keyring.TerminalPrompt).Pointer() {
+		t.Fatalf("FilePasswordFunc should be TerminalPrompt after clearing a protected store")
+	}
+
+	// A subsequent process that knows the original passphrase can write to the
+	// same store. The empty-passphrase probe must still reject that item.
+	next, err := Open(
+		WithAllowFileFallback(true),
+		WithPassphrase(passphrase),
+		WithFileDir(dir),
+	)
+	if err != nil {
+		t.Fatalf("open next store: %v", err)
+	}
+	nextKey := TokenKey("next")
+	if err := next.Set(nextKey, "next-value"); err != nil {
+		t.Fatalf("next set: %v", err)
+	}
+
+	emptyCfg := probeCfg
+	emptyCfg.FilePasswordFunc = keyring.FixedStringPrompt("")
+	emptyStore, err := keyring.Open(emptyCfg)
+	if err == nil {
+		if _, err := emptyStore.Get(nextKey); err == nil {
+			t.Fatalf("empty passphrase unexpectedly decrypted a protected store")
+		}
+	}
+
+	got, err := next.Get(nextKey)
+	if err != nil {
+		t.Fatalf("protected readback: %v", err)
+	}
+	if got != "next-value" {
+		t.Fatalf("protected readback = %q, want %q", got, "next-value")
 	}
 }
 


### PR DESCRIPTION
Supersedes #132 by @fredwangwang — thank you for the fix; this carries your commit as-is and adds the follow-up commit that addresses the three review points so it can land:

- the empty-passphrase probe forces `AllowedBackends` to `[FileBackend]` (never probes another backend);
- new/cleared stores (zero or missing keys) keep `TerminalPrompt`;
- real keyring regression: protected store → delete last item → configure prompts → the next write with the original passphrase stays undecryptable with an empty passphrase.

Local: `go test ./internal/secret`, `make build`, `make test` (E2E package skipped — no docker locally), `make lint` clean. Closes #88 behavior gap noted in the original review.

Co-authored-by: Huan Wang <fredwanghuan@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ