### PR TITLE
docs: first-screen README status so 0.0.36 does not read as unfinished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- README first screen now states who should install this `jk` this week, distinguishes it from the official Jenkins CLI and the unrelated PyPI `jenkins-cli` package, and documents v0.0.36 production vs planned 1.0 scope.
 - Documentation audit against the shipped CLI: README quickstart now streams logs with `jk log --follow` (`jk run view` has no `--follow`), manual skill install points at `skills/jk`, stale version and platform lists updated; `docs/api.md` filter/operator/field catalogs, `run params` `source` values, cancel/rerun acknowledgements and the `help --json` shape corrected, with companion-plugin endpoints marked as planned; the two agent-cookbook recipes that could not work (`--limit 0`, queued-run detection) rewritten; unimplemented command groups in `docs/spec.md` marked *(planned)*; the `jk` skill documents `--no-verify` and the keyring environment variables; stale `docs/CHANGELOG.md` removed.
 ### Fixed
 - Skip the encrypted file keyring passphrase prompt when the secrets directory is empty or existing items unlock with an empty passphrase, so `--allow-insecure-store` no longer asks to unlock unencrypted stores.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <p align="center"><em>GitHub CLI–style workflows for Jenkins controllers</em></p>
 
 <p align="center">
+  <a href="https://github.com/avivsinai/jenkins-cli/releases/latest"><img src="https://img.shields.io/github/v/release/avivsinai/jenkins-cli" alt="Latest release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
   <a href="go.mod"><img src="https://img.shields.io/badge/Go-1.25+-00ADD8.svg" alt="Go Version"></a>
   <a href="https://github.com/avivsinai/jenkins-cli/actions/workflows/ci.yml"><img src="https://github.com/avivsinai/jenkins-cli/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
@@ -10,7 +11,11 @@
   <a href="https://scorecard.dev/viewer/?uri=github.com/avivsinai/jenkins-cli"><img src="https://api.scorecard.dev/projects/github.com/avivsinai/jenkins-cli/badge" alt="OpenSSF Scorecard"></a>
 </p>
 
-`jk` gives developers and operators a modern, scriptable interface to Jenkins: inspect runs, stream logs, manage credentials, and administer controllers from a single cross-platform binary.
+**Install this `jk` this week** if you operate Jenkins and want a single Go binary to search jobs across folders, trigger and follow runs, stream logs, download artifacts, and manage credentials, nodes, queues, and plugins — with JSON/YAML for scripts.
+
+This is **not** the official Jenkins CLI (`jenkins-cli.jar` from your controller, documented on [jenkins.io](https://www.jenkins.io/doc/book/managing/cli/)). We do not publish to PyPI; `pip install jenkins-cli` is a different project.
+
+**Status ([v0.0.36](https://github.com/avivsinai/jenkins-cli/releases/tag/v0.0.36), 11 Aug 2026):** the CLI is released and tested against stock Jenkins LTS REST APIs. Auth, contexts, search, jobs, runs, logs, artifacts, tests, credentials, nodes, queue, and plugins ship today. The version stays 0.x because the 1.0 design still includes a companion plugin plus JCasC, events, and metrics — those are not in this binary.
 
 ## Features
 
@@ -24,6 +29,8 @@
 - **GitHub CLI parity** – command structure and UX mirror `gh`, easing adoption in developer toolchains.
 
 ## Installation
+
+Install the `jk` binary from the paths below. Homebrew uses [`avivsinai/tap`](https://github.com/avivsinai/homebrew-tap) (`jk`); Scoop uses [`avivsinai/scoop-bucket`](https://github.com/avivsinai/scoop-bucket). There is no Nix package and no PyPI project for this CLI.
 
 ### Homebrew (macOS/Linux)
 
@@ -52,7 +59,7 @@ Binary will be installed to `$GOPATH/bin` (or `$HOME/go/bin` by default).
 
 ### Binary Downloads
 
-Download prebuilt binaries for your platform from [GitHub Releases](https://github.com/avivsinai/jenkins-cli/releases).
+Download prebuilt binaries (macOS, Linux, Windows) or `.deb` packages from [GitHub Releases](https://github.com/avivsinai/jenkins-cli/releases).
 
 ### From Source
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Marketing README fix from the 2026-08-19 audit: a Jenkins admin should be able to decide in ~30 seconds whether to install **this** `jk`, not the official Jenkins CLI or the unrelated PyPI package.

Verified before editing:

- Latest shipped release/tag is **v0.0.36** (2026-08-11). Version is **not** bumped; inventing a 1.0 would be dishonest.
- Homebrew `avivsinai/tap` has formula `jk` at 0.0.36.
- Scoop `avivsinai/scoop-bucket` has `bucket/jk.json`.
- There is no Nix package and this project does not publish to PyPI.

The first screen now states:

- Who should install this `jk` this week (operators who want a Go CLI for search/runs/logs/artifacts/creds/nodes/queue/plugins).
- What this is **not** (official `jenkins-cli.jar` / jenkins.io CLI; `pip install jenkins-cli`).
- Honest 0.x status: stock Jenkins REST APIs ship today; companion plugin, JCasC, events, and metrics do not.

No RentSeek mention, no invented stars/downloads/logos.

## Testing

- `make build` — passed
- `JK_E2E_DISABLE=1 make test` — passed (docs-only change)

## Documentation

- [x] Updated README / docs (if user-facing)
- [x] Added release note (if appropriate)

## Checklist

- [x] Code follows project style (`gofmt`, etc.)
- [x] Tests added or updated where needed
- [ ] Related issues linked (if applicable)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1f9eed1-15cd-4b81-a3db-0c0d81b4cd9f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1f9eed1-15cd-4b81-a3db-0c0d81b4cd9f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

