### PR TITLE
docs: tighten README first-screen voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- README first screen now states who should install this `jk` this week, distinguishes it from the official Jenkins CLI and the unrelated PyPI `jenkins-cli` package, and documents v0.0.36 production vs planned 1.0 scope.
+- README first screen names `jk`, who it is for, what it does, one-line official-CLI disambiguation, and the v0.0.36 status (REST APIs ship; companion plugin, JCasC, events, and metrics do not).
 - Documentation audit against the shipped CLI: README quickstart now streams logs with `jk log --follow` (`jk run view` has no `--follow`), manual skill install points at `skills/jk`, stale version and platform lists updated; `docs/api.md` filter/operator/field catalogs, `run params` `source` values, cancel/rerun acknowledgements and the `help --json` shape corrected, with companion-plugin endpoints marked as planned; the two agent-cookbook recipes that could not work (`--limit 0`, queued-run detection) rewritten; unimplemented command groups in `docs/spec.md` marked *(planned)*; the `jk` skill documents `--no-verify` and the keyring environment variables; stale `docs/CHANGELOG.md` removed.
 ### Fixed
 - Skip the encrypted file keyring passphrase prompt when the secrets directory is empty or existing items unlock with an empty passphrase, so `--allow-insecure-store` no longer asks to unlock unencrypted stores.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
   <a href="https://scorecard.dev/viewer/?uri=github.com/avivsinai/jenkins-cli"><img src="https://api.scorecard.dev/projects/github.com/avivsinai/jenkins-cli/badge" alt="OpenSSF Scorecard"></a>
 </p>
 
-**Install this `jk` this week** if you operate Jenkins and want a single Go binary to search jobs across folders, trigger and follow runs, stream logs, download artifacts, and manage credentials, nodes, queues, and plugins — with JSON/YAML for scripts.
+`jk` is a single Go binary for Jenkins operators. Search jobs across folders, trigger and follow runs, stream logs, download artifacts, and manage credentials, nodes, queues, and plugins. Output is human, JSON, or YAML.
 
-This is **not** the official Jenkins CLI (`jenkins-cli.jar` from your controller, documented on [jenkins.io](https://www.jenkins.io/doc/book/managing/cli/)). We do not publish to PyPI; `pip install jenkins-cli` is a different project.
+This is not the official Jenkins CLI (`jenkins-cli.jar`; [jenkins.io](https://www.jenkins.io/doc/book/managing/cli/)).
 
-**Status ([v0.0.36](https://github.com/avivsinai/jenkins-cli/releases/tag/v0.0.36), 11 Aug 2026):** the CLI is released and tested against stock Jenkins LTS REST APIs. Auth, contexts, search, jobs, runs, logs, artifacts, tests, credentials, nodes, queue, and plugins ship today. The version stays 0.x because the 1.0 design still includes a companion plugin plus JCasC, events, and metrics — those are not in this binary.
+**Status ([v0.0.36](https://github.com/avivsinai/jenkins-cli/releases/tag/v0.0.36), 11 Aug 2026):** released and tested against stock Jenkins LTS REST APIs. Auth, contexts, search, jobs, runs, logs, artifacts, tests, credentials, nodes, queue, and plugins ship today. Companion plugin, JCasC, events, and metrics are not in this binary. The version stays 0.x for that reason.
 
 ## Features
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Voice pass on the README first screen. Same facts as #139; no plea to install.

The first screen now:

- Names `jk` and who it is for (Jenkins operators)
- States what it does (search, runs, logs, artifacts, credentials, nodes, queues, plugins; human/JSON/YAML)
- Disambiguates the official Jenkins CLI in one dry sentence
- Keeps the honest **v0.0.36** status: stock Jenkins REST APIs ship; companion plugin, JCasC, events, and metrics do not

Install paths are unchanged: Homebrew `avivsinai/tap/jk`, Scoop `avivsinai/scoop-bucket`. No PyPI claim. No RentSeek. No invented metrics.

## Testing

- `make build` — passed
- `JK_E2E_DISABLE=1 make test` — passed (docs-only change)

## Documentation

- [x] Updated README / docs (if user-facing)
- [x] Added release note (if appropriate)

## Checklist

- [x] Code follows project style (`gofmt`, etc.)
- [ ] Tests added or updated where needed (docs-only)
- [ ] Related issues linked (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-555dc8fa-11fe-4892-a375-76520d2e398a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-555dc8fa-11fe-4892-a375-76520d2e398a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

